### PR TITLE
Add Ignore option to monitor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fim"
-version = "0.0.1"
+version = "0.2.0"
 authors = ["José Fernández <´pylott@gmail.com´>"]
 edition = "2018"
 

--- a/config.yml
+++ b/config.yml
@@ -1,15 +1,18 @@
-version: 0.1.0
+version: 0.2.0
 
 # Monitor folder or files in windows/unix syntax.
 monitor: 
 # Possible monitored folders (Windows examples)
-#  - C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup
-#  - C:\Program Files
+#  - path: C:\ProgramData\Microsoft\Windows\Start Menu\Programs\Startup
+#   ignore: .log
+#  - path: C:\Program Files
 # Possible monitored folders (Linux examples)
-#  - /etc/
-#  - /usr/bin/
-#  - /bin/
-
+#  - path: /etc/
+#      ignore: .cfg
+#  - path: /usr/bin/
+#  - path: /bin/
+  - path: C:\
+    ignore: .log
 
 # Path to output and events files:
 # output to write app log.

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,8 @@ use std::sync::mpsc::channel;
 // To log the program process
 use log::*;
 use simplelog::{WriteLogger, Config};
+// To manage paths
+use std::path::Path;
 
 // To load configuration functions
 mod config;
@@ -14,16 +16,17 @@ mod events;
 
 // Main function where the magic happens
 fn main() {
+    println!("Reading config...");
+
     let config_path = "config.yml";
     let config = config::read_config(config_path);
     let paths = &config[0]["monitor"];
-    //let delay:u64 = config[0]["watcher"]["delay"].as_i64().unwrap().try_into().unwrap();
     let log_file = &config[0]["log"]["output"]["file"].as_str().unwrap();
     let log_level = &config[0]["log"]["output"]["level"].as_str().unwrap();
     let events_file = &config[0]["log"]["events"]["file"].as_str().unwrap();
     let events_format = &config[0]["log"]["events"]["format"].as_str().unwrap();
+    let ignores = &config[0]["ignore"];
     
-    println!("Reading config...");
     println!("Config file: {}", config_path);
     println!("Log file: {}", log_file);
     println!("Events file: {}", events_file);
@@ -55,6 +58,20 @@ fn main() {
         match rx.recv() {
             Ok(event) => {
                 debug!("Event registered: {:?}", event);
+                for ignore in ignores.as_vec().unwrap() {
+                    let ignore_path = Path::new(ignore.as_str().unwrap());
+                    let ignore_parent_path = ignore_path.parent().unwrap().to_str().unwrap();
+                    let event_path = Path::new(event.path.as_ref().unwrap().to_str().unwrap());
+                    let event_parent_path = event_path.parent().unwrap().to_str().unwrap();
+                    println!("Event path: {}", event_path.to_str().unwrap());
+                    println!("Ignore path: {}", ignore_path.to_str().unwrap());
+                    println!("Event parent path: {}", event_parent_path);
+                    println!("Ignore parent path: {}", ignore_parent_path);
+                    //match parent {
+                    //    event.path => println!('EQUALS');
+                    //}
+                    //println!("Character: {}",  );
+                }
                 events::log_event(events_file, event, events_format)
             },
             Err(e) => error!("Watch error: {:?}", e),

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,9 @@ use std::sync::mpsc::channel;
 use log::*;
 use simplelog::{WriteLogger, Config};
 // To manage paths
-use std::path::Path;
+//use std::path::Path;
+mod monitor;
+use monitor::Monitor;
 
 // To load configuration functions
 mod config;
@@ -20,7 +22,8 @@ fn main() {
 
     let config_path = "config.yml";
     let config = config::read_config(config_path);
-    let paths = &config[0]["monitor"];
+    let monitor = &config[0]["monitor"];
+    //println!("{}", monitor.as_str().unwrap());
     let log_file = &config[0]["log"]["output"]["file"].as_str().unwrap();
     let log_level = &config[0]["log"]["output"]["level"].as_str().unwrap();
     let events_file = &config[0]["log"]["events"]["file"].as_str().unwrap();
@@ -47,10 +50,18 @@ fn main() {
     // Iterating over monitor paths and set each watcher to watch.
     let (tx, rx) = channel();
     let mut watcher: RecommendedWatcher = Watcher::new_raw(tx).unwrap();
-    for p in paths.as_vec().unwrap() {
-        let path = p.as_str().unwrap();
-        info!("Monitoring path: {}", path);
-        watcher.watch(path, RecursiveMode::Recursive).unwrap();
+    for m in monitor.as_vec().unwrap() {
+        
+        println!( "{}", &m["path"].as_str().unwrap() );
+        println!( "{}", &m["ignore"].as_str().unwrap() );
+        let mon = Monitor {
+            path: String::from(m["path"].as_str().unwrap()),
+            ignore: String::from(m["ignore"].as_str().unwrap())
+        };
+        
+        info!("Monitoring path: {}", mon.path);
+        info!("Ignoring files with: {}", mon.ignore);
+        watcher.watch(mon.path, RecursiveMode::Recursive).unwrap();
     }
 
     // Main loop, receive any produced event and write into the events log.
@@ -58,7 +69,7 @@ fn main() {
         match rx.recv() {
             Ok(event) => {
                 debug!("Event registered: {:?}", event);
-                for ignore in ignores.as_vec().unwrap() {
+                /*for ignore in ignores.as_vec().unwrap() {
                     let ignore_path = Path::new(ignore.as_str().unwrap());
                     let ignore_parent_path = ignore_path.parent().unwrap().to_str().unwrap();
                     let event_path = Path::new(event.path.as_ref().unwrap().to_str().unwrap());
@@ -67,11 +78,14 @@ fn main() {
                     println!("Ignore path: {}", ignore_path.to_str().unwrap());
                     println!("Event parent path: {}", event_parent_path);
                     println!("Ignore parent path: {}", ignore_parent_path);
+
+                    //if event_parent_path != ignore_parent_path
+
                     //match parent {
                     //    event.path => println!('EQUALS');
                     //}
                     //println!("Character: {}",  );
-                }
+                }*/
                 events::log_event(events_file, event, events_format)
             },
             Err(e) => error!("Watch error: {:?}", e),

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,4 +1,0 @@
-pub struct Monitor {
-    pub path: String,
-    pub ignore: String
-}

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -1,0 +1,4 @@
+pub struct Monitor {
+    pub path: String,
+    pub ignore: String
+}


### PR DESCRIPTION
Hello!

We have added ignore option to monitoring path, this option works like a match in the produced event filename.
If the event filename contains the ignore word the event will not be stored.