### PR TITLE
Compile package with Glibc 2.17

### DIFF
--- a/pkg/rpm/repository/release/fim-0.2.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.2.0-1.x86_64.rpm
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:80ce5a71ca8422301660eac79e42fc566990ea7cfebda6f4d9ace27fc4c55ba7
-size 408252
+oid sha256:aa228a4ce930dc54633535d80576b9d6e1a0be8ca7d7249835121ed47f573900
+size 1030424


### PR DESCRIPTION
Hello team,

On this PR we closes #14 We have compiled the package on CentOS 7 distribution. Uploaded to release inside LFS repository.

Thanks @alberpilot nice catch!

Regards.