### PR TITLE
Change data path and perform package and software improvements

### DIFF
--- a/config/linux/config.yml
+++ b/config/linux/config.yml
@@ -15,8 +15,8 @@ log:
   output: 
     file: /var/log/fim/fim.log
     # Possible levels debug, info, error, warning
-    level: debug
+    level: info
   events:
-    file: /usr/share/fim/events.json
+    file: /var/lib/fim/events.json
     # Format of output events options json/syslog
     format: json

--- a/config/windows/config.yml
+++ b/config/windows/config.yml
@@ -14,7 +14,7 @@ log:
   output: 
     file: C:\ProgramData\fim\fim.log
     # Possible levels debug, info, error, warning
-    level: debug
+    level: info
   events:
     file: C:\ProgramData\fim\events.json
     # Format of output events options json/syslog

--- a/config/windows/config.yml
+++ b/config/windows/config.yml
@@ -5,7 +5,6 @@ nodename: "FIM"
 monitor: 
   - path: C:\Program Files\
   - path: C:\Users\
-  - path: C:\Windows\Temp\
 
 # Path to output and events files:
 # output to write app log.

--- a/pkg/deb/debian/changelog
+++ b/pkg/deb/debian/changelog
@@ -1,6 +1,8 @@
 fim (0.2.1-1) devel; urgency=medium
 
   * Added UUID to events
+  * Improved Debian package purge and removal
+  * Changed events folder to /var/lib/fim
   * More info: https://github.com/Achiefs/fim/releases/tag/v0.2.1
 
  -- Jose Fernandez <support@achiefs.com>  Tue, 18 Jan 2022 23:00:00 +0000

--- a/pkg/deb/debian/postrm
+++ b/pkg/deb/debian/postrm
@@ -1,12 +1,17 @@
 #!/bin/sh
 set -e
 
-INSTALL_DIR="/usr/local"
+INSTALL_DIR="/usr"
+DOC_DIR="${INSTALL_DIR}/share/doc/fim"
 
 case "$1" in
     remove|failed-upgrade|abort-install|abort-upgrade|disappear)
         rm -rf ${INSTALL_DIR}/bin/fim
+    ;;
+
+    purge)
         rm -rf ${INSTALL_DIR}/etc/fim/config.yml
+        rm -rf ${DOC_DIR}
     ;;
 
     upgrade)

--- a/pkg/rpm/fim.spec
+++ b/pkg/rpm/fim.spec
@@ -33,14 +33,7 @@ install -m 0640 config/linux/config.yml ${RPM_BUILD_ROOT}%{_configdir}/
 %pre
 %post
 %preun
-
 %postun
-# If the package is been uninstalled
-if [ $1 = 0 ];then
-  # Remove lingering folders and files
-  rm -f %{_bindir}/%{name}
-  rm -rf %{_configdir}
-fi
 
 %clean
 rm -fr %{buildroot}

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -52,143 +52,147 @@ impl Event {
         }
     }
 
-  // --------------------------------------------------------------------------
+    // ------------------------------------------------------------------------
 
-  // Function to write the received events to file
-  pub fn log_event(&self, file: &str, format: &str){
-      let mut log = OpenOptions::new()
-          .create(true)
-          .write(true)
-          .append(true)
-          .open(file)
-          .expect("Unable to open events log file.");
+    // Function to write the received events to file
+    pub fn log_event(&self, file: &str, format: &str){
+        let mut log = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .append(true)
+            .open(file)
+            .expect("Unable to open events log file.");
 
-      let clean_format: &str;
-      match format {
-          "json" | "JSON" | "j" | "J" | "Json" => clean_format = "JSON",
-          "syslog" | "s" | "SYSLOG" | "S" | "Syslog" | _ => clean_format = "SYSLOG",
-      }
-      let mut obj = self.get_common_message(clean_format);
-      let message = format!("{} {} {}[{}]:",
-              obj["timestamp"], obj["hostname"], obj["node"], obj["pid"]);
+        let clean_format: &str;
+        match format {
+            "json" | "JSON" | "j" | "J" | "Json" => clean_format = "JSON",
+            "syslog" | "s" | "SYSLOG" | "S" | "Syslog" | _ => clean_format = "SYSLOG",
+        }
+        let mut obj = self.get_common_message(clean_format);
+        let message = format!("{} {} {}[{}]:",
+                obj["timestamp"], obj["hostname"], obj["node"], obj["pid"]);
 
-      match self.operation {
-          Op::CREATE => {
-              let md = metadata(&self.path).unwrap();
-              let checksum = match md.is_file() {
-                  true => {
-                      match hash::get_checksum(&self.path.to_str().unwrap()) {
-                          Ok(data) => data,
-                          Err(_e) => String::from("IGNORED")
-                      }
-                  },
-                  false => String::from("IGNORED")
-              };
+        match self.operation {
+            Op::CREATE => {
+                let checksum = match metadata(&self.path){
+                    Ok(metadata_struct) => {
+                        match metadata_struct.is_file() {
+                            true => {
+                                match hash::get_checksum(&self.path.to_str().unwrap()) {
+                                    Ok(data) => data,
+                                    Err(_e) => String::from("IGNORED")
+                                }
+                            },
+                            false => String::from("IGNORED")
+                        }
+                    },
+                    Err(_e) => String::from("IGNORED")
+                };
 
-              if clean_format == "JSON" {
-                  obj["kind"] = "CREATE".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  obj["checksum"] = checksum.into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} File '{}' created, checksum {}", message,
-                      self.path.to_str().unwrap(), checksum)
-              }
-          }
-          Op::WRITE => {
-              let checksum = match hash::get_checksum(&self.path.to_str().unwrap()) {
-                  Ok(data) => data,
-                  Err(_e) => String::from("IGNORED")
-              };
+                if clean_format == "JSON" {
+                    obj["kind"] = "CREATE".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    obj["checksum"] = checksum.into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} File '{}' created, checksum {}", message,
+                        self.path.to_str().unwrap(), checksum)
+                }
+            }
+            Op::WRITE => {
+                let checksum = match hash::get_checksum(&self.path.to_str().unwrap()) {
+                    Ok(data) => data,
+                    Err(_e) => String::from("IGNORED")
+                };
 
-              if clean_format == "JSON" {
-                  obj["kind"] = "WRITE".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  obj["checksum"] = checksum.into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} File '{}' written, new checksum {}", message,
-                      self.path.to_str().unwrap(), checksum)
-              }
-          }
-          Op::RENAME => {
-              let checksum = match metadata(&self.path) {
-                  Ok(md) => {
-                      match md.is_file() {
-                          true => {
-                              match hash::get_checksum(&self.path.to_str().unwrap()) {
-                                  Ok(data) => data,
-                                  Err(e) => {
-                                      match e.kind() {
-                                          ErrorKind::NotFound => println!("File Not found error ignoring..."),
-                                          _ => panic!("Not handled error on get_checksum function."),
-                                      };
-                                      String::from("IGNORED")
-                                  }
-                              }
-                          },
-                          false => String::from("IGNORED")
-                      }
-                  },
-                  Err(_e) => String::from("IGNORED")
-              };
-              if clean_format == "JSON" {
-                  obj["kind"] = "RENAME".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  obj["checksum"] = checksum.into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} File '{}' renamed, checksum {}", message,
-                      self.path.to_str().unwrap(), checksum)
-              }
-          }
-          Op::REMOVE => {
-              if clean_format == "JSON" {
-                  obj["kind"] = "REMOVE".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} File '{}' removed", message,
-                      self.path.to_str().unwrap())
-              }
-          },
-          Op::CHMOD => {
-              if clean_format == "JSON" {
-                  obj["kind"] = "CHMOD".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} File '{}' permissions modified", message,
-                      self.path.to_str().unwrap())
-              }
-          },
-          Op::CLOSE_WRITE => {
-              if clean_format == "JSON" {
-                  obj["kind"] = "CLOSE_WRITE".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} File '{}' closed", message,
-                      self.path.to_str().unwrap())
-              }
-          },
-          Op::RESCAN => {
-              if clean_format == "JSON" {
-                  obj["kind"] = "RESCAN".into();
-                  obj["file"] = self.path.to_str().unwrap().into();
-                  writeln!(log, "{}", json::stringify(obj))
-              } else {
-                  writeln!(log, "{} Directory '{}' need to be rescaned", message,
-                      self.path.to_str().unwrap())
-              }
-          },
-          _ => {
-              let error_msg = "Event Op not Handled or do not exists";
-              error!("{}", error_msg);
-              Err(Error::new(ErrorKind::InvalidInput, error_msg))
-          },
-      }.expect("Error writing event")
-  }
+                if clean_format == "JSON" {
+                    obj["kind"] = "WRITE".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    obj["checksum"] = checksum.into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} File '{}' written, new checksum {}", message,
+                        self.path.to_str().unwrap(), checksum)
+                }
+            }
+            Op::RENAME => {
+                let checksum = match metadata(&self.path) {
+                    Ok(md) => {
+                        match md.is_file() {
+                            true => {
+                                match hash::get_checksum(&self.path.to_str().unwrap()) {
+                                    Ok(data) => data,
+                                    Err(e) => {
+                                        match e.kind() {
+                                            ErrorKind::NotFound => println!("File Not found error ignoring..."),
+                                            _ => panic!("Not handled error on get_checksum function."),
+                                        };
+                                        String::from("IGNORED")
+                                    }
+                                }
+                            },
+                            false => String::from("IGNORED")
+                        }
+                    },
+                    Err(_e) => String::from("IGNORED")
+                };
+                if clean_format == "JSON" {
+                    obj["kind"] = "RENAME".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    obj["checksum"] = checksum.into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} File '{}' renamed, checksum {}", message,
+                        self.path.to_str().unwrap(), checksum)
+                }
+            }
+            Op::REMOVE => {
+                if clean_format == "JSON" {
+                    obj["kind"] = "REMOVE".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} File '{}' removed", message,
+                        self.path.to_str().unwrap())
+                }
+            },
+            Op::CHMOD => {
+                if clean_format == "JSON" {
+                    obj["kind"] = "CHMOD".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} File '{}' permissions modified", message,
+                        self.path.to_str().unwrap())
+                }
+            },
+            Op::CLOSE_WRITE => {
+                if clean_format == "JSON" {
+                    obj["kind"] = "CLOSE_WRITE".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} File '{}' closed", message,
+                        self.path.to_str().unwrap())
+                }
+            },
+            Op::RESCAN => {
+                if clean_format == "JSON" {
+                    obj["kind"] = "RESCAN".into();
+                    obj["file"] = self.path.to_str().unwrap().into();
+                    writeln!(log, "{}", json::stringify(obj))
+                } else {
+                    writeln!(log, "{} Directory '{}' need to be rescaned", message,
+                        self.path.to_str().unwrap())
+                }
+            },
+            _ => {
+                let error_msg = "Event Op not Handled or do not exists";
+                error!("{}", error_msg);
+                Err(Error::new(ErrorKind::InvalidInput, error_msg))
+            },
+        }.expect("Error writing event")
+    }
 }
 
 impl fmt::Debug for Event {

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,6 @@ fn main() {
     let events_file = &config[0]["log"]["events"]["file"].as_str().unwrap();
     let events_format = &config[0]["log"]["events"]["format"].as_str().unwrap();
     
-    println!("Config file: {}", selected_path);
     println!("Log file: {}", log_file);
     println!("Events file: {}", events_file);
     println!("Log level: {}", log_level);


### PR DESCRIPTION
Hello all,

This PR closes #15 
We have added the following changes:
- Changed events default path to `/var/lib` instead of `/usr/share`
- Increased log level by default to INFO
- Removed uncommon path in Windows configuration file
- Fix Remove and purge steps of Debian package
- Removed unnecessary `%postun` code in RPM package SPEC
- Removed duplicated print in `main.rs`
- Fixed tabulations in `event.rs` file
- Fixed edge case on file creation, the `CREATE` event on some cases produce error when the file is deleted at the same time that we get the checksum. We have ignored the operation in such cases.

Regards.