### PR TITLE
Add unit tests of function code

### DIFF
--- a/.github/workflows/code-testing-workflow.yml
+++ b/.github/workflows/code-testing-workflow.yml
@@ -9,6 +9,7 @@ jobs:
       - name: Building the rust code
         run: cargo build
       - run: echo "Job's status is ${{ job.status }}."
+
   Compilation-test-windows:
     runs-on: windows-2019
     steps:
@@ -16,4 +17,13 @@ jobs:
         uses: actions/checkout@v2
       - name: Building the rust code
         run: cargo build
+      - run: echo "Job's status is ${{ job.status }}."
+
+  Unit-tests:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check out repository code, branch='${{ github.ref }}'
+        uses: actions/checkout@v2
+      - name: Launch cargo test
+        run: cargo test
       - run: echo "Job's status is ${{ job.status }}."

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,10 +34,125 @@ pub fn get_log_level(level: String, log_file: String) -> LevelFilter {
         "error" | "Error" | "ERROR" | "E" | "e" => LevelFilter::Error,
         "warning" | "Warning" | "WARNING" | "W" | "w" | "warn" | "Warn" | "WARN" => LevelFilter::Warn,
         _ => {
-            let msg = String::from("ERROR reading log level from 'config.yml', using Debug by default");
+            let msg = String::from("ERROR reading log level from 'config.yml', using Info by default");
             println!("{}", msg);
             writeln!(log, "{}", msg).expect("Error writing Error in log.");
-            LevelFilter::Debug
+            LevelFilter::Info
         }
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn remove_test_file(filename: &str) {
+        fs::remove_file(filename).unwrap()
+    }
+
+    #[test]
+    fn test_get_log_level_info() {
+        let file = "info.txt";
+        let filename = String::from(file);
+        let filter = LevelFilter::Info;
+        assert_eq!(get_log_level(String::from("info"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("Info"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("INFO"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("I"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("i"), filename.clone()), filter);
+        remove_test_file(file);
+    }
+
+    #[test]
+    fn test_get_log_level_debug() {
+        let file = "debug.txt";
+        let filename = String::from(file);
+        let filter = LevelFilter::Debug;
+        assert_eq!(get_log_level(String::from("debug"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("Debug"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("DEBUG"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("D"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("d"), filename.clone()), filter);
+        remove_test_file(file);
+    }
+
+    #[test]
+    fn test_get_log_level_error() {
+        let file = "error.txt";
+        let filename = String::from(file);
+        let filter = LevelFilter::Error;
+        assert_eq!(get_log_level(String::from("error"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("Error"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("ERROR"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("E"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("e"), filename.clone()), filter);
+        remove_test_file(file);
+    }
+
+    #[test]
+    fn test_get_log_level_warning() {
+        let file = "warning.txt";
+        let filename = String::from(file);
+        let filter = LevelFilter::Warn;
+        assert_eq!(get_log_level(String::from("warning"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("Warning"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("WARNING"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("W"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("w"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("warn"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("Warn"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("WARN"), filename.clone()), filter);
+        remove_test_file(file);
+    }
+
+    #[test]
+    fn test_get_log_level_bad() {
+        let file = "bad.txt";
+        let filename = String::from(file);
+        let filter = LevelFilter::Info;
+        assert_eq!(get_log_level(String::from("bad"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("BAD"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("B"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("b"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("test"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("anything"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from(""), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("_"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("?"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("="), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("/"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("."), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from(":"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from(";"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("!"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("''"), filename.clone()), filter);
+        assert_eq!(get_log_level(String::from("[]"), filename.clone()), filter);
+        remove_test_file(file);
+    }
+
+    #[test]
+    #[should_panic(expected = "NotFound")]
+    fn test_get_log_level_panic_empty() {
+        get_log_level("".to_string(), "".to_string());
+    }
+
+    #[test]
+    fn test_read_config() {
+        read_config("config/linux/config.yml");
+    }
+
+    #[test]
+    #[should_panic(expected = "NotFound")]
+    fn test_read_config_panic() {
+        read_config("not_found");
+    }
+
+    #[test]
+    #[should_panic(expected = "ScanError")]
+    fn test_read_config_panic_not_config() {
+        read_config("README.md");
     }
 }

--- a/src/event/event.rs
+++ b/src/event/event.rs
@@ -33,7 +33,15 @@ impl Event {
     // To get JSON object of common data.
     fn get_common_message(&self, format: &str) -> JsonValue {
         match format {
-            "JSON" => {
+            "SYSLOG" => {
+                json::object![
+                    timestamp: self.timestamp.clone(),
+                    hostname: self.hostname.clone(),
+                    node: self.nodename.clone(),
+                    pid: process::id()
+                ]
+            },
+            "JSON" | _ => {
                 json::object![
                     id: self.id.clone(),
                     timestamp: self.timestamp.clone(),
@@ -41,14 +49,6 @@ impl Event {
                     node: self.nodename.clone(),
                     pid: process::id(),
                     version: self.version.clone()
-                ]
-            },
-            "SYSLOG" | _ => {
-                json::object![
-                    timestamp: self.timestamp.clone(),
-                    hostname: self.hostname.clone(),
-                    node: self.nodename.clone(),
-                    pid: process::id()
                 ]
             },
         }
@@ -67,8 +67,8 @@ impl Event {
 
         let clean_format: &str;
         match format {
-            "json" | "JSON" | "j" | "J" | "Json" => clean_format = "JSON",
-            "syslog" | "s" | "SYSLOG" | "S" | "Syslog" | _ => clean_format = "SYSLOG",
+            "syslog" | "s" | "SYSLOG" | "S" | "Syslog" => clean_format = "SYSLOG",
+            "json" | "JSON" | "j" | "J" | "Json" | _ => clean_format = "JSON",
         }
         let mut obj = self.get_common_message(clean_format);
         let message = format!("{} {} {}[{}]:",
@@ -204,5 +204,109 @@ impl fmt::Debug for Event {
           .field(&self.path)
           .field(&self.operation)
           .finish()
+    }
+}
+
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::event::Event;
+    use notify::op::Op;
+    use std::path::PathBuf;
+    use std::process;
+    use std::fs;
+
+    fn remove_test_file(filename: &str) {
+        fs::remove_file(filename).unwrap()
+    }
+
+    fn create_test_event() -> Event {
+        Event {
+            id: "Test_id".to_string(),
+            timestamp: "Timestamp".to_string(),
+            hostname: "Hostname".to_string(),
+            nodename: "FIM".to_string(),
+            version: "x.x.x".to_string(),
+            operation: Op::CREATE,
+            path: PathBuf::new()
+        }
+    }
+
+    #[test]
+    fn test_create_event() {
+        let evt = create_test_event();
+        assert_eq!(evt.id, "Test_id".to_string());
+        assert_eq!(evt.timestamp, "Timestamp".to_string());
+        assert_eq!(evt.hostname, "Hostname".to_string());
+        assert_eq!(evt.nodename, "FIM".to_string());
+        assert_eq!(evt.version, "x.x.x".to_string());
+        assert_eq!(evt.operation, Op::CREATE);
+        assert_eq!(evt.path, PathBuf::new());
+    }
+
+    #[test]
+    fn test_get_common_message_syslog() {
+        let evt = create_test_event();
+        let expected_output = json::object![
+            timestamp: evt.timestamp.clone(),
+            hostname: evt.hostname.clone(),
+            node: evt.nodename.clone(),
+            pid: process::id()
+        ];
+        assert_eq!(evt.get_common_message("SYSLOG"), expected_output);
+    }
+
+    #[test]
+    fn test_get_common_message_json() {
+        let evt = create_test_event();
+        let expected_output = json::object![
+            id: evt.id.clone(),
+            timestamp: evt.timestamp.clone(),
+            hostname: evt.hostname.clone(),
+            node: evt.nodename.clone(),
+            pid: process::id(),
+            version: evt.version.clone()
+        ];
+        assert_eq!(evt.get_common_message("JSON"), expected_output);
+    }
+
+    #[test]
+    fn test_get_common_message_default() {
+        let evt = create_test_event();
+        let expected_output = json::object![
+            id: evt.id.clone(),
+            timestamp: evt.timestamp.clone(),
+            hostname: evt.hostname.clone(),
+            node: evt.nodename.clone(),
+            pid: process::id(),
+            version: evt.version.clone()
+        ];
+        assert_eq!(evt.get_common_message("TEST"), expected_output);
+        assert_eq!(evt.get_common_message(""), expected_output);
+    }
+
+    #[test]
+    fn test_log_event_json() {
+        let filename = "test_event.json";
+        let evt = create_test_event();
+
+        evt.log_event(filename, "JSON");
+        let contents = fs::read_to_string(filename);
+        let expected = format!("{{\"id\":\"Test_id\",\"timestamp\":\"Timestamp\",\"hostname\":\"Hostname\",\"node\":\"FIM\",\"pid\":{},\"version\":\"x.x.x\",\"kind\":\"CREATE\",\"file\":\"\",\"checksum\":\"IGNORED\"}}\n", process::id());
+        assert_eq!(contents.unwrap(), expected);
+        remove_test_file(filename);
+    }
+
+    #[test]
+    fn test_log_event_syslog() {
+        let filename = "test_event.log";
+        let evt = create_test_event();
+
+        evt.log_event(filename, "SYSLOG");
+        let contents = fs::read_to_string(filename);
+        let expected = format!("Timestamp Hostname FIM[{}]: File '' created, checksum IGNORED\n", process::id());
+        assert_eq!(contents.unwrap(), expected);
+        remove_test_file(filename);
     }
 }

--- a/src/event/hash.rs
+++ b/src/event/hash.rs
@@ -19,3 +19,43 @@ pub fn get_checksum(file: &str) -> Result<String, Error> {
         Err(e) => return Err(e),
     }
 }
+
+// ----------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::fs::File;
+    use std::io::prelude::*;
+
+    fn create_test_file(filename: &str) {
+        File::create(filename).unwrap().write_all(b"This is a test!").unwrap();
+    }
+
+    fn remove_test_file(filename: &str) {
+        fs::remove_file(filename).unwrap()
+    }
+
+    #[test]
+    fn test_get_checksum_file() {
+        let filename = "test_get_checksum_file";
+        create_test_file(filename);
+        assert_eq!(get_checksum(filename).unwrap(), "46512636eeeb22dee0d60f3aba6473b1fb3258dc0c9ed6fbdbf26bed06df796bc70d4c1f6d50ca977b45f35b494e4bd9fb34e55a1576d6d9a3b5e1ab059953ee");
+        remove_test_file(filename);
+    }
+
+    #[test]
+    #[should_panic(expected = "NotFound")]
+    fn test_get_checksum_panic() {
+        assert_ne!(get_checksum("not_exists").unwrap(), "This is a test");
+    }
+
+    #[test]
+    fn test_get_checksum_bad() {
+        let filename = "test_get_checksum_bad";
+        create_test_file(filename);
+        assert_ne!(get_checksum(filename).unwrap(), "This is a test");
+        remove_test_file(filename);
+    }
+}


### PR DESCRIPTION
Hi!

This PR closes #8 

We are glad to announce a new test compilation yay!
We have added tests to the functions:
- `hash.rs`, `get_checksum` function
- `config.rs`, `read_config` and `get_log_level` functions
- `event.rs`, `get_common_message` and `log_event` functions

We included a total of 18 tests:
1. test_get_log_level_panic_empty
2. test_read_config_panic
3. test_read_config
4. test_create_event
5. test_get_common_message_default
6. test_get_common_message_json
7. test_get_common_message_syslog
8. test_get_log_level_info
9. test_get_log_level_error
10. test_get_log_level_debug
11. test_get_log_level_warning
12. test_get_checksum_bad
13. test_get_checksum_file
14. test_read_config_panic_not_config - should panic
15. test_get_checksum_panic - should panic
16. test_log_event_syslog
17. test_log_event_json
18. test_get_log_level_bad

We have included a workflow step to launch such unit tests with `cargo test`