### PR TITLE
Change ignore parameter to be an array

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,4 +16,5 @@ simplelog = "0.11.2"
 gethostname = "0.2.1"
 json = "0.12.4"
 retry = "1.2.0"
+itertools = "0.10.3"
 uuid = { version = "0.8.2", features = ["v4"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -112,7 +112,10 @@ fn main() {
                     let path = it["path"].as_str().unwrap();
                     let value = if path.ends_with('/') || path.ends_with("\\"){ pop(path) }else{ path };
                     event_parent_path.contains(value) &&
-                    !it["ignore"].as_vec().unwrap().iter().any(|ignore| { event_filename.to_str().unwrap().contains(ignore.as_str().unwrap()) })
+                    !match it["ignore"].as_vec(){
+                        Some(ig) => ig.iter().any(|ignore| { event_filename.to_str().unwrap().contains(ignore.as_str().unwrap()) }),
+                        None => true
+                    }
                 }){
                     let timestamp = format!("{:?}", SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis());
                     let hostname = format!("{}", gethostname::gethostname().into_string().unwrap());


### PR DESCRIPTION
Allows to eg. exclude multiple filenames in ignore directive. My rust knowledge isn't great so there is maybe better way to do it. I have used Itertools to add possibility to use ```.intersperse()``` without moving to nightly/experimental, another possibility but not elegant is to use ```.join()``` and trim last character.