### PR TITLE
Improve hashing of large files

### DIFF
--- a/src/auditevent.rs
+++ b/src/auditevent.rs
@@ -150,7 +150,8 @@ impl Event {
             path: utils::clean_path(&event_path),
             file: utils::get_filename_path(path["name"].clone().as_str()),
             checksum: hash::get_checksum(format!("{}/{}",
-                parent["name"].clone(), path["name"].clone())),
+                parent["name"].clone(), path["name"].clone()),
+                config.events_max_file_checksum),
             fpid: utils::get_pid(),
             system: utils::get_os(),
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
     pub version: String,
     pub path: String,
     pub events_destination: String,
+    pub events_max_file_checksum: usize,
     pub endpoint_address: String,
     pub endpoint_user: String,
     pub endpoint_pass: String,
@@ -48,6 +49,7 @@ impl Config {
             version: self.version.clone(),
             path: self.path.clone(),
             events_destination: self.events_destination.clone(),
+            events_max_file_checksum: self.events_max_file_checksum,
             endpoint_address: self.endpoint_address.clone(),
             endpoint_user: self.endpoint_user.clone(),
             endpoint_pass: self.endpoint_pass.clone(),
@@ -88,6 +90,12 @@ impl Config {
                     String::from("Not_used")
                 }
             }
+        };
+
+        // Manage null value on events->max_file_checksum value
+        let events_max_file_checksum = match yaml[0]["events"]["max_file_checksum"].as_str() {
+            Some(value) => value.parse().unwrap(),
+            None => 64
         };
 
         // Manage null value on events->endpoint->insecure value
@@ -199,6 +207,7 @@ impl Config {
             version: String::from(VERSION),
             path: config_path,
             events_destination,
+            events_max_file_checksum,
             endpoint_address,
             endpoint_user,
             endpoint_pass,
@@ -362,6 +371,7 @@ mod tests {
             version: String::from(VERSION),
             path: String::from("test"),
             events_destination: String::from(events_destination),
+            events_max_file_checksum: 64,
             endpoint_address: String::from("test"),
             endpoint_user: String::from("test"),
             endpoint_pass: String::from("test"),
@@ -385,6 +395,7 @@ mod tests {
         assert_eq!(config.version, cloned.version);
         assert_eq!(config.path, cloned.path);
         assert_eq!(config.events_destination, cloned.events_destination);
+        assert_eq!(config.events_max_file_checksum, cloned.events_max_file_checksum);
         assert_eq!(config.endpoint_address, cloned.endpoint_address);
         assert_eq!(config.endpoint_user, cloned.endpoint_user);
         assert_eq!(config.endpoint_pass, cloned.endpoint_pass);

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -1,35 +1,57 @@
 // Copyright (C) 2021, Achiefs.
 
+// Constants definitions
+const READ_CAPACITY: usize = 1024 * 1024 * 8; // Read file in chunks of 8MB
+
 // To get file checksums
 use hex::{encode, decode};
 use sha3::{Sha3_512, Digest};
-use std::io::ErrorKind;
 // To log the program process
 use log::*;
 // To manage hex to ascii conversion
 use std::str;
+// To manage files
+use std::fs::File;
+// To read file content
+use std::io::{BufRead, BufReader};
 
 // To calculate file content hash in sha512 format (SHA3 implementation)
-pub fn get_checksum(file: String) -> String {
+pub fn get_checksum(filename: String, read_limit: usize) -> String {
     let mut hasher = Sha3_512::new();
-    match std::fs::read_to_string(file) {
-        Ok(data) => {
-            hasher.update(&data);
-            let result = hasher.finalize().to_vec();
-            encode(result)
-        },
-        Err(e) => {
-            match e.kind() {
-                ErrorKind::NotFound => {
-                    debug!("File Not found error ignoring...");
-                    String::from("UNKNOWN")
-                },
-                _ => {
-                    debug!("Error not handled: {:?}", e.kind());
-                    String::from("UNKNOWN")
-                },
+    let mut length = 1;
+    let mut iteration = 0;
+    let mut data_read = 0;
+    
+    debug!("Getting hash of file: {}", filename);
+    match File::open(filename.clone()){
+        Ok(file) => {
+            let mut reader = BufReader::with_capacity(READ_CAPACITY, file);
+
+            while length > 0 && data_read <= read_limit {
+                if iteration == 2 {
+                    info!("Big file detected, the hash will take a while");
+                }
+                
+                length = {
+                    let buffer = reader.fill_buf().unwrap();
+                    hasher.update(&buffer);
+                    buffer.len()
+                };
+                reader.consume(length);
+                data_read += length / (1024 * 1024);
+                iteration += 1;
+            };
+            if data_read > read_limit {
+                info!("File '{}' checksum skipped. File size is above limit", filename);
+                String::from("UNKNOWN")
+            }else{
+                encode(hasher.finalize())
             }
         },
+        Err(e) => {
+            debug!("Cannot open file to get checksum, error: {:?}", e);
+            String::from("UNKNOWN")
+        }
     }
 }
 
@@ -52,6 +74,8 @@ pub fn hex_to_ascii(hex: String) -> String {
 
 #[cfg(test)]
 mod tests {
+    const MAX_FILE_READ: usize = 64;
+
     use super::*;
     use std::fs;
     use std::fs::File;
@@ -71,7 +95,7 @@ mod tests {
     fn test_get_checksum_file() {
         let filename = String::from("test_get_checksum_file");
         create_test_file(filename.clone());
-        assert_eq!(get_checksum(filename.clone()), String::from("46512636eeeb22dee0d60f3aba6473b1fb3258dc0c9ed6fbdbf26bed06df796bc70d4c1f6d50ca977b45f35b494e4bd9fb34e55a1576d6d9a3b5e1ab059953ee"));
+        assert_eq!(get_checksum(filename.clone(), MAX_FILE_READ), String::from("46512636eeeb22dee0d60f3aba6473b1fb3258dc0c9ed6fbdbf26bed06df796bc70d4c1f6d50ca977b45f35b494e4bd9fb34e55a1576d6d9a3b5e1ab059953ee"));
         remove_test_file(filename.clone());
     }
 
@@ -79,8 +103,8 @@ mod tests {
 
     #[test]
     fn test_get_checksum_not_exists() {
-        assert_ne!(get_checksum(String::from("not_exists")), String::from("This is a test"));
-        assert_eq!(get_checksum(String::from("not_exists")), String::from("UNKNOWN"));
+        assert_ne!(get_checksum(String::from("not_exists"), MAX_FILE_READ), String::from("This is a test"));
+        assert_eq!(get_checksum(String::from("not_exists"), MAX_FILE_READ), String::from("UNKNOWN"));
     }
 
     // ------------------------------------------------------------------------
@@ -89,7 +113,7 @@ mod tests {
     fn test_get_checksum_bad() {
         let filename = String::from("test_get_checksum_bad");
         create_test_file(filename.clone());
-        assert_ne!(get_checksum(filename.clone()), String::from("This is a test"));
+        assert_ne!(get_checksum(filename.clone(), MAX_FILE_READ), String::from("This is a test"));
         remove_test_file(filename.clone());
     }
 

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -36,7 +36,7 @@ pub fn get_checksum(filename: String, read_limit: usize) -> String {
                     
                     length = {
                         let buffer = reader.fill_buf().unwrap();
-                        hasher.update(&buffer);
+                        hasher.update(buffer);
                         buffer.len()
                     };
                     reader.consume(length);

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -253,7 +253,7 @@ pub async fn monitor(tx: mpsc::Sender<Result<notify::Event, notify::Error>>,
                                     labels,
                                     operation: event::get_operation(kind.clone()),
                                     detailed_operation: event::get_detailed_operation(kind),
-                                    checksum: hash::get_checksum( String::from(path.to_str().unwrap()) ),
+                                    checksum: hash::get_checksum( String::from(path.to_str().unwrap()), config.events_max_file_checksum ),
                                     fpid: utils::get_pid(),
                                     system: config.system.clone()
                                 };


### PR DESCRIPTION
Hello!

This PR closes #90.

We have included the following features:
- Improved hashing function to allow big files hashing (Up to 64MB by default).
- Included configuration parameter to increase the file hashing limit (It increases the execution time also).
- Avoid hash directories.

Thanks!