### PR TITLE
Include log panics crate, improve cofiguration load and unit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ tokio-util = { version = "0.7.1", default-features = false, features = ["codec"]
 serde_json = { version = "1.0.79", default-features = false }
 time = { version = "0.3.17", default-features = false }
 ctrlc = { version = "3.2", default-features = false, features = ["termination"] }
+log-panics = { version = "2.1.0", features = ["with-backtrace"]}
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.5.0"

--- a/src/auditevent.rs
+++ b/src/auditevent.rs
@@ -561,7 +561,7 @@ mod tests {
     #[test]
     fn test_from() {
         if utils::get_os() == "linux" {
-            let config = Config::new(&utils::get_os());
+            let config = Config::new(&utils::get_os(), None);
             let syscall = HashMap::<String, String>::from([
                 (String::from("syscall"), String::from("syscall")),
                 (String::from("ppid"), String::from("ppid")),
@@ -920,7 +920,7 @@ mod tests {
 
     #[test]
     fn test_process() {
-        let config = Config::new(&utils::get_os());
+        let config = Config::new(&utils::get_os(), None);
         let event = create_test_event();
 
         block_on(event.process(config::NETWORK_MODE, String::from("test"), config.clone()));

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,7 @@ use crate::utils;
 
 // ----------------------------------------------------------------------------
 
+#[derive(Clone)]
 pub struct Config {
     pub version: String,
     pub path: String,
@@ -65,9 +66,9 @@ impl Config {
     }
 
     pub fn new(system: &str) -> Self {
-        println!("[INFO] System detected {}", system);
+        println!("System detected '{}'", system);
         let config_path = get_config_path(system);
-        println!("[INFO] Loaded config from: {}", config_path);
+        println!("Loaded config from: '{}'", config_path);
         let yaml = read_config(config_path.clone());
 
         // Manage null value on events->destination value

--- a/src/config.rs
+++ b/src/config.rs
@@ -179,8 +179,14 @@ impl Config {
             Some(value) => String::from(value),
             None => {
                 match system {
-                    "linux" => utils::get_hostname(),
-                    "macos" => utils::get_hostname(),
+                    "linux" => match utils::get_machine_id().is_empty() {
+                        true => utils::get_hostname(),
+                        false => utils::get_machine_id()
+                    },
+                    "macos" => match utils::get_machine_id().is_empty(){
+                        true => utils::get_hostname(),
+                        false => utils::get_machine_id()
+                    }
                     _ => {
                         println!("[WARN] node not found in config.yml, using hostname.");
                         utils::get_hostname()
@@ -739,22 +745,6 @@ mod tests {
         let config = Config::new("linux", Some("test/unit/config/linux/log_level_none.yml"));
         assert_eq!(config.log_level, "info");
     }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
     // ------------------------------------------------------------------------
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -725,7 +725,11 @@ mod tests {
     #[test]
     fn test_new_config_linux_node_none() {
         let config = Config::new("linux", Some("test/unit/config/linux/node_none.yml"));
-        assert_eq!(config.node, utils::get_hostname());
+        let machine_id = utils::get_machine_id();
+        match machine_id.is_empty(){
+            true => assert_eq!(config.node, utils::get_hostname()),
+            false => assert_eq!(config.node, machine_id)
+        }
     }
 
     // ------------------------------------------------------------------------

--- a/src/event.rs
+++ b/src/event.rs
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn test_process() {
-        let config = Config::new(&utils::get_os());
+        let config = Config::new(&utils::get_os(), None);
         let event = create_test_event();
 
         block_on(event.process(config::NETWORK_MODE, String::from("test"), config.clone()));

--- a/src/logreader.rs
+++ b/src/logreader.rs
@@ -142,7 +142,7 @@ mod tests {
     #[test]
     fn test_read_log() {
         if utils::get_os() == "linux" {
-            let config = Config::new("linux");
+            let config = Config::new("linux", None);
             let (event, position) = read_log(String::from("test/unit/audit.log"),
                 config, 0, 0);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,7 +37,7 @@ fn init(){
     use std::fs;
 
     println!("Achiefs File Integrity Monitoring software starting!");
-    println!("Reading config...");
+    println!("[INFO] Reading config...");
     unsafe{
         GCONFIG = Some(config::Config::new(&utils::get_os(), None));    
 
@@ -59,9 +59,9 @@ fn init(){
                 .expect("Unable to open log file")
         ).unwrap();
 
-        println!("Configuration successfully read, forwarding output to log file");
-        println!("Log file: '{}'", GCONFIG.clone().unwrap().log_file);
-        println!("Log level: '{}'", GCONFIG.clone().unwrap().log_level);
+        println!("[INFO] Configuration successfully read, forwarding output to log file");
+        println!("[INFO] Log file: '{}'", GCONFIG.clone().unwrap().log_file);
+        println!("[INFO] Log level: '{}'", GCONFIG.clone().unwrap().log_level);
     };
     log_panics::init();
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,7 +39,7 @@ fn init(){
     println!("Achiefs File Integrity Monitoring software starting!");
     println!("Reading config...");
     unsafe{
-        GCONFIG = Some(config::Config::new(&utils::get_os()));    
+        GCONFIG = Some(config::Config::new(&utils::get_os(), None));    
 
         // Create folders to store logs based on config.yml
         fs::create_dir_all(

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,12 +26,54 @@ mod service;
 // Manage monitor methods
 mod monitor;
 
+static mut GCONFIG: Option<config::Config> = None;
+
+// ----------------------------------------------------------------------------
+
+fn init(){
+    use std::path::Path;
+    use simplelog::WriteLogger;
+    use simplelog::Config;
+    use std::fs;
+
+    println!("Achiefs File Integrity Monitoring software starting!");
+    println!("Reading config...");
+    unsafe{
+        GCONFIG = Some(config::Config::new(&utils::get_os()));    
+
+        // Create folders to store logs based on config.yml
+        fs::create_dir_all(
+            Path::new( &GCONFIG.clone().unwrap().log_file
+            ).parent().unwrap().to_str().unwrap()
+        ).unwrap();
+
+        // Create logger output to write generated logs.
+        WriteLogger::init(
+            GCONFIG.clone().unwrap().get_level_filter(),
+            Config::default(),
+            fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .append(true)
+                .open(GCONFIG.clone().unwrap().log_file)
+                .expect("Unable to open log file")
+        ).unwrap();
+
+        println!("Configuration successfully read, forwarding output to log file");
+        println!("Log file: '{}'", GCONFIG.clone().unwrap().log_file);
+        println!("Log level: '{}'", GCONFIG.clone().unwrap().log_level);
+    };
+    log_panics::init();
+}
+
 // ----------------------------------------------------------------------------
 
 // Main function where the magic happens
 #[cfg(not(windows))]
 #[tokio::main]
 async fn main() {
+    init();
+
     let (tx, rx) = mpsc::channel();
     monitor::monitor(tx, rx).await;
 }
@@ -41,6 +83,8 @@ async fn main() {
 #[cfg(windows)]
 #[tokio::main]
 async fn main() -> windows_service::Result<()> {
+    init();
+
     // To manage terminal parameters
     use std::env;
     let args: Vec<_> = env::args().collect();

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -52,6 +52,7 @@ fn setup_logger(config: config::Config){
             .open(config.log_file)
             .expect("Unable to open log file")
     ).unwrap();
+    log_panics::init();
 }
 
 // ----------------------------------------------------------------------------

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -35,7 +35,7 @@ use crate::logreader;
 
 // ----------------------------------------------------------------------------
 
-fn setup_events(destination: &str, gconfig: config::Config){
+fn setup_events(destination: &str, config: config::Config){
     // Perform actions depending on destination
     info!("Events destination selected: {}", destination);
     match destination {
@@ -43,20 +43,20 @@ fn setup_events(destination: &str, gconfig: config::Config){
             debug!("Events folder not created in network mode");
         },
         _ => {
-            info!("Events file: {}", gconfig.events_file);
-            fs::create_dir_all(Path::new(&gconfig.events_file).parent().unwrap().to_str().unwrap()).unwrap()
+            info!("Events file: {}", config.events_file);
+            fs::create_dir_all(Path::new(&config.events_file).parent().unwrap().to_str().unwrap()).unwrap()
         }
     }
 }
 
 // ----------------------------------------------------------------------------
 
-async fn push_template(destination: &str, gconfig: config::Config){
+async fn push_template(destination: &str, config: config::Config){
     // Perform actions depending on destination
     match destination {
         config::NETWORK_MODE|config::BOTH_MODE => {
             // On start push template (Include check if events won't be ingested by http)
-            index::push_template(gconfig.endpoint_address, gconfig.endpoint_user, gconfig.endpoint_pass, gconfig.insecure).await;
+            index::push_template(config.endpoint_address, config.endpoint_user, config.endpoint_pass, config.insecure).await;
         },
         _ => {
             debug!("Template not pushed in file mode");

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_push_template() {
-        let config = config::Config::new(&utils::get_os());
+        let config = config::Config::new(&utils::get_os(), None);
         fs::create_dir_all(Path::new(&config.log_file).parent().unwrap().to_str().unwrap()).unwrap();
         block_on(push_template("file", config.clone()));
         block_on(push_template("network", config.clone()));
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_setup_events() {
-        let config = config::Config::new(&utils::get_os());
+        let config = config::Config::new(&utils::get_os(), None);
         fs::create_dir_all(Path::new(&config.log_file).parent().unwrap().to_str().unwrap()).unwrap();
         setup_events("file", config.clone());
         setup_events("network", config.clone());

--- a/test/unit/config/linux/audit_and_monitor_none.yml
+++ b/test/unit/config/linux/audit_and_monitor_none.yml
@@ -1,0 +1,12 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/audit_none.yml
+++ b/test/unit/config/linux/audit_none.yml
@@ -1,0 +1,20 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_credentials_password.yml
+++ b/test/unit/config/linux/events_credentials_password.yml
@@ -1,0 +1,30 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_credentials_password_none.yml
+++ b/test/unit/config/linux/events_credentials_password_none.yml
@@ -1,0 +1,29 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_credentials_user.yml
+++ b/test/unit/config/linux/events_credentials_user.yml
@@ -1,0 +1,30 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_credentials_user_none.yml
+++ b/test/unit/config/linux/events_credentials_user_none.yml
@@ -1,0 +1,29 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      password: test
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_destination_network.yml
+++ b/test/unit/config/linux/events_destination_network.yml
@@ -1,0 +1,30 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_destination_network_address.yml
+++ b/test/unit/config/linux/events_destination_network_address.yml
@@ -1,0 +1,31 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+    insecure: true
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_destination_network_address_none.yml
+++ b/test/unit/config/linux/events_destination_network_address_none.yml
@@ -1,0 +1,30 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    credentials:
+      user: test
+      password: test
+    insecure: true
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_destination_none.yml
+++ b/test/unit/config/linux/events_destination_none.yml
@@ -1,0 +1,25 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_endpoint_insecure.yml
+++ b/test/unit/config/linux/events_endpoint_insecure.yml
@@ -1,0 +1,32 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+    insecure: true
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_endpoint_insecure_none.yml
+++ b/test/unit/config/linux/events_endpoint_insecure_none.yml
@@ -1,0 +1,31 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_file_none.yml
+++ b/test/unit/config/linux/events_file_none.yml
@@ -1,0 +1,25 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/events_max_file_checksum.yml
+++ b/test/unit/config/linux/events_max_file_checksum.yml
@@ -1,0 +1,27 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+  max_file_checksum: 128
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/log_file_none.yml
+++ b/test/unit/config/linux/log_file_none.yml
@@ -1,0 +1,25 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/log_level_none.yml
+++ b/test/unit/config/linux/log_level_none.yml
@@ -1,0 +1,25 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]

--- a/test/unit/config/linux/monitor_none.yml
+++ b/test/unit/config/linux/monitor_none.yml
@@ -1,0 +1,18 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/node_none.yml
+++ b/test/unit/config/linux/node_none.yml
@@ -1,0 +1,24 @@
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_credentials_password.yml
+++ b/test/unit/config/windows/events_credentials_password.yml
@@ -1,0 +1,23 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_credentials_password_none.yml
+++ b/test/unit/config/windows/events_credentials_password_none.yml
@@ -1,0 +1,22 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_credentials_user.yml
+++ b/test/unit/config/windows/events_credentials_user.yml
@@ -1,0 +1,23 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_credentials_user_none.yml
+++ b/test/unit/config/windows/events_credentials_user_none.yml
@@ -1,0 +1,22 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_destination_network.yml
+++ b/test/unit/config/windows/events_destination_network.yml
@@ -1,0 +1,23 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_destination_network_address.yml
+++ b/test/unit/config/windows/events_destination_network_address.yml
@@ -1,0 +1,23 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_destination_network_address_none.yml
+++ b/test/unit/config/windows/events_destination_network_address_none.yml
@@ -1,0 +1,22 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  endpoint:
+    credentials:
+      user: test
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_destination_none.yml
+++ b/test/unit/config/windows/events_destination_none.yml
@@ -1,0 +1,18 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  file: C:\ProgramData\fim\events.json
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_endpoint_insecure.yml
+++ b/test/unit/config/windows/events_endpoint_insecure.yml
@@ -1,0 +1,25 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+    insecure: true
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_endpoint_insecure_none.yml
+++ b/test/unit/config/windows/events_endpoint_insecure_none.yml
@@ -1,0 +1,24 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: network
+  file: C:\ProgramData\fim\events.json
+  endpoint:
+    address: 0.0.0.0
+    credentials:
+      user: test
+      password: test
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_file_none.yml
+++ b/test/unit/config/windows/events_file_none.yml
@@ -1,0 +1,18 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/events_max_file_checksum.yml
+++ b/test/unit/config/windows/events_max_file_checksum.yml
@@ -1,0 +1,20 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+  max_file_checksum: 128
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/log_file_none.yml
+++ b/test/unit/config/windows/log_file_none.yml
@@ -1,0 +1,18 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/log_level_none.yml
+++ b/test/unit/config/windows/log_level_none.yml
@@ -1,0 +1,18 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]

--- a/test/unit/config/windows/monitor_none.yml
+++ b/test/unit/config/windows/monitor_none.yml
@@ -1,0 +1,12 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/node_none.yml
+++ b/test/unit/config/windows/node_none.yml
@@ -1,0 +1,17 @@
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info


### PR DESCRIPTION
Hello!

This PR closes #97, #98 and #99

We have added the following:
- Added log-panics crate to log any error to defined log.
- Added init method in main to initialize the configuration.
- Moved configuration to static zone (required to next issues).
- Moved configuration setup to main init function.
- Added specific configuration unit tests.