### PR TITLE
Include allow list to filter monitoring files

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1043,4 +1043,23 @@ mod tests {
         }
     }
 
+    // ------------------------------------------------------------------------
+
+    #[test]
+    fn test_match_allowed() {
+        if utils::get_os() == "windows" {
+            let config = Config::new(&utils::get_os(), Some("test/unit/config/windows/monitor_allowed.yml"));
+            assert!(!config.match_allowed(1, "file.swp", config.monitor.clone()));
+            assert!(config.match_allowed(1, "file.txt", config.monitor.clone()));
+        } else if utils::get_os() == "linux" {
+            let config = Config::new(&utils::get_os(), Some("test/unit/config/linux/monitor_allowed.yml"));
+            assert!(!config.match_allowed(2, "file.swp", config.monitor.clone()));
+            assert!(config.match_allowed(2, "file.txt", config.monitor.clone()));
+
+            let config_audit = Config::new(&utils::get_os(), Some("test/unit/config/linux/audit_allowed.yml"));
+            assert!(!config_audit.match_allowed(0, "file.swp", config_audit.audit.clone()));
+            assert!(config_audit.match_allowed(0, "file.txt", config_audit.audit.clone()));
+        }
+    }
+
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -305,6 +305,15 @@ impl Config {
 
     // ------------------------------------------------------------------------
 
+    pub fn match_allowed(&self, index: usize, filename: &str, array: Array) -> bool {
+        match array[index]["allowed"].as_vec() {
+            Some(allowed) => allowed.to_vec().iter().any(|allw| filename.contains(allw.as_str().unwrap())),
+            None => true
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
     // Returns if a given path and filename is in the configuration paths
     pub fn path_in(&self, raw_path: &str, cwd: &str, vector: Vec<Yaml>) -> bool {
         // Iterate over monitoring paths to match ignore string and ignore event or not

--- a/src/event.rs
+++ b/src/event.rs
@@ -285,6 +285,27 @@ mod tests {
     // ------------------------------------------------------------------------
 
     #[test]
+    fn test_clone() {
+        let event = create_test_event();
+        let cloned = event.clone();
+        assert_eq!(event.id, cloned.id);
+        assert_eq!(event.timestamp, cloned.timestamp);
+        assert_eq!(event.hostname, cloned.hostname);
+        assert_eq!(event.node, cloned.node);
+        assert_eq!(event.version, cloned.version);
+        assert_eq!(event.path, cloned.path);
+        assert_eq!(event.kind, cloned.kind);
+        assert_eq!(event.labels, cloned.labels);
+        assert_eq!(event.operation, cloned.operation);
+        assert_eq!(event.detailed_operation, cloned.detailed_operation);
+        assert_eq!(event.checksum, cloned.checksum);
+        assert_eq!(event.fpid, cloned.fpid);
+        assert_eq!(event.system, cloned.system);
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[test]
     fn test_create_event() {
         let evt = create_test_event();
         assert_eq!(evt.id, "Test_id".to_string());

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -74,10 +74,6 @@ pub fn get_event_integration(event: Event, integrations: Vec<Integration>) -> Op
     let option = integrations.iter().find(|integration|
         match integration.condition[1].as_str() {
             "==" => event.get_string(integration.condition[0].clone()) == integration.condition[2],
-            ">" => event.get_string(integration.condition[0].clone()) > integration.condition[2],
-            "<" => event.get_string(integration.condition[0].clone()) < integration.condition[2],
-            ">=" => event.get_string(integration.condition[0].clone()) >= integration.condition[2],
-            "<=" => event.get_string(integration.condition[0].clone()) <= integration.condition[2],
             "!=" => event.get_string(integration.condition[0].clone()) != integration.condition[2],
             _ => false
         }
@@ -124,6 +120,48 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
+    #[cfg(target_os = "windows")]
+    pub fn create_dummy_event_windows(path: &str, operation: &str) -> Event {
+        Event{
+            id: "Test_id".to_string(),
+            timestamp: "Timestamp".to_string(),
+            hostname: "Hostname".to_string(),
+            node: "FIM".to_string(),
+            version: "x.x.x".to_string(),
+            kind: EventKind::Create(CreateKind::Any),
+            path: PathBuf::from(format!("C:\\{}\\test.txt", path)),
+            labels: Vec::new(),
+            operation: operation.to_string(),
+            detailed_operation: "CREATE_FILE".to_string(),
+            checksum: "UNKNOWN".to_string(),
+            fpid: 0,
+            system: "test".to_string()
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[cfg(any(target_os = "linux", target_os = "darwin"))]
+    pub fn create_dummy_event_unix(path: &str, operation: &str) -> Event {
+        Event{
+            id: "Test_id".to_string(),
+            timestamp: "Timestamp".to_string(),
+            hostname: "Hostname".to_string(),
+            node: "FIM".to_string(),
+            version: "x.x.x".to_string(),
+            kind: EventKind::Create(CreateKind::Any),
+            path: PathBuf::from(format!("/{}/test.txt", path)),
+            labels: Vec::new(),
+            operation: operation.to_string(),
+            detailed_operation: "CREATE_FILE".to_string(),
+            checksum: "UNKNOWN".to_string(),
+            fpid: 0,
+            system: "test".to_string()
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
     #[test]
     fn test_clone() {
         let integration = create_test_integration();
@@ -161,26 +199,10 @@ mod tests {
     #[test]
     fn test_get_event_integration_windows() {
         let config = Config::new("windows", Some("test/unit/config/windows/monitor_integration.yml"));
-        let event = Event{
-            id: "Test_id".to_string(),
-            timestamp: "Timestamp".to_string(),
-            hostname: "Hostname".to_string(),
-            node: "FIM".to_string(),
-            version: "x.x.x".to_string(),
-            kind: EventKind::Create(CreateKind::Any),
-            path: PathBuf::from("C:\\tmp\\test.txt"),
-            labels: Vec::new(),
-            operation: "CREATE".to_string(),
-            detailed_operation: "CREATE_FILE".to_string(),
-            checksum: "UNKNOWN".to_string(),
-            fpid: 0,
-            system: "test".to_string()
-        };
 
-        let index = config.get_index(event.path.to_str().unwrap(), "", config.monitor.clone());
-        let integrations = config.get_integrations(index, config.monitor.clone());
-
-        let integration = get_event_integration(event, integrations).unwrap();
+        let integrations = config.get_integrations(2, config.monitor.clone());
+        let event = create_dummy_event_windows("tmp", "CREATE");
+        let integration = get_event_integration(event, integrations.clone()).unwrap();
 
         assert_eq!(integration.name, "rmfile");
         assert_eq!(integration.condition[0], "operation");
@@ -189,6 +211,18 @@ mod tests {
         assert_eq!(integration.binary, "powershell.exe");
         assert_eq!(integration.script, "C:\\tmp\\remover.ps1");
         assert_eq!(integration.parameters, "");
+
+        let integrations2 = config.get_integrations(3, config.monitor.clone());
+        let event2 = create_dummy_event_windows("tmp2", "MODIFY");
+        let integration2 = get_event_integration(event2, integrations2.clone()).unwrap();
+
+        assert_eq!(integration2.name, "rmfile2");
+        assert_eq!(integration2.condition[0], "operation");
+        assert_eq!(integration2.condition[1], "!=");
+        assert_eq!(integration2.condition[2], "REMOVE");
+        assert_eq!(integration2.binary, "powershell.exe");
+        assert_eq!(integration2.script, "C:\\tmp\\remover.ps1");
+        assert_eq!(integration2.parameters, "");
     }
 
     // ------------------------------------------------------------------------
@@ -198,25 +232,9 @@ mod tests {
     fn test_get_event_integration_unix() {
         let os = utils::get_os();
         let config = Config::new(&os, Some(format!("test/unit/config/{}/monitor_integration.yml", os).as_str()));
-        let event = Event{
-            id: "Test_id".to_string(),
-            timestamp: "Timestamp".to_string(),
-            hostname: "Hostname".to_string(),
-            node: "FIM".to_string(),
-            version: "x.x.x".to_string(),
-            kind: EventKind::Create(CreateKind::Any),
-            path: PathBuf::from("/etc/test.txt"),
-            labels: Vec::new(),
-            operation: "CREATE".to_string(),
-            detailed_operation: "CREATE_FILE".to_string(),
-            checksum: "UNKNOWN".to_string(),
-            fpid: 0,
-            system: "test".to_string()
-        };
 
-        let index = config.get_index(event.path.to_str().unwrap(), "", config.monitor.clone());
-        let integrations = config.get_integrations(index, config.monitor.clone());
-
+        let event = create_dummy_event_unix("etc", "CREATE");
+        let integrations = config.get_integrations(2, config.monitor.clone());
         let integration = get_event_integration(event, integrations).unwrap();
 
         assert_eq!(integration.name, "rmfile");
@@ -226,6 +244,18 @@ mod tests {
         assert_eq!(integration.binary, "bash");
         assert_eq!(integration.script, "/tmp/remover.sh");
         assert_eq!(integration.parameters, "");
+
+        let event2 = create_dummy_event_unix("etc2", "MODIFY");
+        let integrations2 = config.get_integrations(3, config.monitor.clone());
+        let integration2 = get_event_integration(event2, integrations2).unwrap();
+
+        assert_eq!(integration2.name, "rmfile2");
+        assert_eq!(integration2.condition[0], "operation");
+        assert_eq!(integration2.condition[1], "!=");
+        assert_eq!(integration2.condition[2], "REMOVE");
+        assert_eq!(integration2.binary, "bash");
+        assert_eq!(integration2.script, "/tmp/remover.sh");
+        assert_eq!(integration2.parameters, "");
     }
 
     // ------------------------------------------------------------------------
@@ -235,6 +265,38 @@ mod tests {
         let out = format!("{:?}", create_test_integration());
         assert_eq!(out,
             "(\"Name\", [\"A\", \"B\", \"C\"], \"Binary\", \"Script\", \"Parameters\")");
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_launch_windows(){
+        let integration = Integration {
+            name: String::from("Name"),
+            condition: [String::from("A"), String::from("B"), String::from("C")].to_vec(),
+            binary: String::from("powershell.exe"),
+            script: String::from("ls"),
+            parameters: String::from("")
+        };
+
+        integration.launch(create_dummy_event_windows("tmp", "C").format_json());
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[cfg(any(target_os = "linux", target_os = "darwin"))]
+    #[test]
+    fn test_launch_unix(){
+        let integration = Integration {
+            name: String::from("Name"),
+            condition: [String::from("A"), String::from("B"), String::from("C")].to_vec(),
+            binary: String::from("bash"),
+            script: String::from("ls"),
+            parameters: String::from("")
+        };
+
+        integration.launch(create_dummy_event_windows("tmp", "C").format_json());
     }
 
 }

--- a/src/integration.rs
+++ b/src/integration.rs
@@ -296,7 +296,7 @@ mod tests {
             parameters: String::from("")
         };
 
-        integration.launch(create_dummy_event_windows("tmp", "C").format_json());
+        integration.launch(create_dummy_event_unix("etc", "C").format_json());
     }
 
 }

--- a/test/unit/config/linux/audit_allowed.yml
+++ b/test/unit/config/linux/audit_allowed.yml
@@ -1,0 +1,27 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+    allowed: [".txt", ".rs"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/monitor_allowed.yml
+++ b/test/unit/config/linux/monitor_allowed.yml
@@ -1,0 +1,27 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+    allowed: [".txt", ".rs"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/monitor_integration.yml
+++ b/test/unit/config/linux/monitor_integration.yml
@@ -24,6 +24,14 @@ monitor:
         binary: bash
         script: /tmp/remover.sh
         parameters: ""
+  - path: /etc2
+    labels: ["etc2", "linux"]
+    integrations:
+      - name: rmfile2
+        condition: ["operation", "!=", "REMOVE"]
+        binary: bash
+        script: /tmp/remover.sh
+        parameters: ""
 
 # App procedure and errors logging
 log:

--- a/test/unit/config/macos/monitor_integration.yml
+++ b/test/unit/config/macos/monitor_integration.yml
@@ -18,6 +18,14 @@ monitor:
         binary: bash
         script: /tmp/remover.sh
         parameters: ""
+  - path: /etc2
+    labels: ["etc2", "macos"]
+    integrations:
+      - name: rmfile2
+        condition: ["operation", "!=", "REMOVE"]
+        binary: bash
+        script: /tmp/remover.sh
+        parameters: ""
 
 # App procedure and errors logging
 log:

--- a/test/unit/config/windows/monitor_allowed.yml
+++ b/test/unit/config/windows/monitor_allowed.yml
@@ -1,0 +1,20 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+    allowed: [".txt", ".rs"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/monitor_integration.yml
+++ b/test/unit/config/windows/monitor_integration.yml
@@ -18,6 +18,13 @@ monitor:
         binary: powershell.exe
         script: C:\tmp\remover.ps1
         parameters: ""
+  - path: C:\tmp2\
+    integrations:
+      - name: rmfile2
+        condition: ["operation", "!=", "REMOVE"]
+        binary: powershell.exe
+        script: C:\tmp\remover.ps1
+        parameters: ""
 
 # App procedure and errors logging
 log:


### PR DESCRIPTION
Hello!

Our community user @ducna96 report that FIM could improve if it includes a way to filter files. It is commonly called the allow list. 
We have included this development in 0.4.6 FIM version that will be released soon.
We also included unit configuration tests.

This issue is related to #109.

Regards!