### PR TITLE
Bump Notify crate to 6.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 
 [dependencies]
 yaml-rust = "0.4"
-notify = "5.2.0"
+notify = "6.1.0"
 simplelog = "0.12.0" # Candidate to remove
 itertools = "0.11.0"
 hex = "0.4.3"


### PR DESCRIPTION
Hello!

We have bumped Notify from 5.2 to 6.1. We have tested the effects of this change. It only affects the `RENAME` detailed operation. It changes to `MODIFY_RENAME_TO` or `MODIFY_RENAME_FROM`

This PR closes #127 