### PR TITLE
Include events and log file rotation, fix timming errors and audit tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ sha3 = { version = "0.10.0", default-features = false }
 log = { version = "0.4.11", default-features = false }
 gethostname = { version = "0.4.0", default-features = false }
 uuid = { version = "1.0.0", default-features = false, features = ["v4"] }
-reqwest = { version = "0.11.18", default-features = false, features = ["json", "stream", "rustls-tls"] }
+reqwest = { version = "0.11.22", default-features = false, features = ["json", "stream", "rustls-tls"] }
 tokio = { version = "1.18.4", default-features = false, features = ["rt", "rt-multi-thread", "macros"] }
 tokio-util = { version = "0.7.8", default-features = false, features = ["codec"] }
 serde_json = { version = "1.0.79", default-features = false }
@@ -27,6 +27,7 @@ log-panics = { version = "2.1.0", features = ["with-backtrace"]}
 
 [target.'cfg(windows)'.dependencies]
 windows-service = "0.6.0"
+zip = "0.6.6"
 
 [dev-dependencies]
 tokio-test = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,5 +29,9 @@ log-panics = { version = "2.1.0", features = ["with-backtrace"]}
 windows-service = "0.6.0"
 zip = "0.6.6"
 
+[target.'cfg(unix)'.dependencies]
+flate2 = "1.0.27"
+tar = "0.4.40"
+
 [dev-dependencies]
 tokio-test = "*"

--- a/src/auditevent.rs
+++ b/src/auditevent.rs
@@ -407,13 +407,13 @@ impl Event {
     pub async fn process(&self, destination: &str, index_name: String, config: config::Config){
         match destination {
             config::BOTH_MODE => {
-                self.log(&config.events_file);
+                self.log(&config.get_events_file());
                 self.send(index_name).await;
             },
             config::NETWORK_MODE => {
                 self.send(index_name).await;
             },
-            _ => self.log(&config.events_file)
+            _ => self.log(&config.get_events_file())
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -34,6 +34,7 @@ pub struct Config {
     pub events_watcher: String,
     pub events_destination: String,
     pub events_max_file_checksum: usize,
+    pub events_max_file_size: usize,
     pub endpoint_type: String,
     pub endpoint_address: String,
     pub endpoint_user: String,
@@ -45,9 +46,13 @@ pub struct Config {
     pub node: String,
     pub log_file: String,
     pub log_level: String,
+    pub log_max_file_size: usize,
     pub system: String,
     pub insecure: bool
 }
+
+pub static mut TMP_EVENTS: bool = false;
+pub static mut TMP_LOG: bool = false;
 
 impl Config {
 
@@ -57,7 +62,8 @@ impl Config {
             path: self.path.clone(),
             events_watcher: self.events_watcher.clone(),
             events_destination: self.events_destination.clone(),
-            events_max_file_checksum: self.events_max_file_checksum,
+            events_max_file_checksum: self.events_max_file_checksum.clone(),
+            events_max_file_size: self.events_max_file_size.clone(),
             endpoint_type: self.endpoint_type.clone(),
             endpoint_address: self.endpoint_address.clone(),
             endpoint_user: self.endpoint_user.clone(),
@@ -69,18 +75,19 @@ impl Config {
             node: self.node.clone(),
             log_file: self.log_file.clone(),
             log_level: self.log_level.clone(),
+            log_max_file_size: self.log_max_file_size.clone(),
             system: self.system.clone(),
             insecure: self.insecure
         }
     }
 
     pub fn new(system: &str, config_path: Option<&str>) -> Self {
-        println!("System detected '{}'", system);
+        println!("[INFO] System detected '{}'", system);
         let cfg = match config_path {
             Some(path) => String::from(path),
             None => get_config_path(system)
         };
-        println!("Loaded config from: '{}'", cfg);
+        println!("[INFO] Loaded config from: '{}'", cfg);
         let yaml = read_config(cfg.clone());
 
         // Manage null value on events->destination value
@@ -118,6 +125,12 @@ impl Config {
         let events_max_file_checksum = match yaml[0]["events"]["max_file_checksum"].as_i64() {
             Some(value) => usize::try_from(value).unwrap(),
             None => 64
+        };
+
+        // Manage null value on events->max_file_size value
+        let events_max_file_size = match yaml[0]["events"]["events_max_file_size"].as_i64() {
+            Some(value) => usize::try_from(value).unwrap(),
+            None => 128
         };
 
         // Manage null value on events->endpoint->insecure value
@@ -252,12 +265,19 @@ impl Config {
             }
         };
 
+        // Manage null value on log->max_file_size value
+        let log_max_file_size = match yaml[0]["log"]["max_file_size"].as_i64() {
+            Some(value) => usize::try_from(value).unwrap(),
+            None => 64
+        };
+
         Config {
             version: String::from(VERSION),
             path: cfg,
             events_watcher,
             events_destination,
             events_max_file_checksum,
+            events_max_file_size,
             endpoint_type,
             endpoint_address,
             endpoint_user,
@@ -269,6 +289,7 @@ impl Config {
             node,
             log_file,
             log_level,
+            log_max_file_size,
             system: String::from(system),
             insecure
         }
@@ -391,6 +412,18 @@ impl Config {
         integrations
     }
 
+    // ------------------------------------------------------------------------
+
+    pub fn get_events_file(&self) -> String {
+        unsafe {
+            if TMP_EVENTS == true {
+                format!("{}.tmp", self.events_file.clone())
+            }else{
+                self.events_file.clone()
+            }
+        }
+    }
+
 }
 
 
@@ -457,6 +490,7 @@ mod tests {
             events_watcher: String::from("Recommended"),
             events_destination: String::from(events_destination),
             events_max_file_checksum: 64,
+            events_max_file_size: 128,
             endpoint_type: String::from("Elastic"),
             endpoint_address: String::from("test"),
             endpoint_user: String::from("test"),
@@ -468,6 +502,7 @@ mod tests {
             node: String::from("test"),
             log_file: String::from("./test.log"),
             log_level: String::from(filter),
+            log_max_file_size: 64,
             system: String::from("test"),
             insecure: true
         }
@@ -483,6 +518,7 @@ mod tests {
         assert_eq!(config.path, cloned.path);
         assert_eq!(config.events_destination, cloned.events_destination);
         assert_eq!(config.events_max_file_checksum, cloned.events_max_file_checksum);
+        assert_eq!(config.events_max_file_size, cloned.events_max_file_size);
         assert_eq!(config.endpoint_type, cloned.endpoint_type);
         assert_eq!(config.endpoint_address, cloned.endpoint_address);
         assert_eq!(config.endpoint_user, cloned.endpoint_user);
@@ -494,6 +530,7 @@ mod tests {
         assert_eq!(config.node, cloned.node);
         assert_eq!(config.log_file, cloned.log_file);
         assert_eq!(config.log_level, cloned.log_level);
+        assert_eq!(config.log_max_file_size, cloned.log_max_file_size);
         assert_eq!(config.system, cloned.system);
         assert_eq!(config.insecure, cloned.insecure);
     }
@@ -517,6 +554,7 @@ mod tests {
         assert_eq!(config.node, String::from("FIM"));
         assert_eq!(config.log_file, String::from("C:\\ProgramData\\fim\\fim.log"));
         assert_eq!(config.log_level, String::from("info"));
+        assert_eq!(config.log_max_file_size, 64);
         assert_eq!(config.system, String::from("windows"));
         assert_eq!(config.insecure, false);
     }
@@ -555,6 +593,15 @@ mod tests {
     fn test_new_config_windows_events_max_file_checksum() {
         let config = Config::new("windows", Some("test/unit/config/windows/events_max_file_checksum.yml"));
         assert_eq!(config.events_max_file_checksum, 128);
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_new_config_windows_events_max_file_size() {
+        let config = Config::new("windows", Some("test/unit/config/windows/events_max_file_size.yml"));
+        assert_eq!(config.events_max_file_size, 256);
     }
 
     // ------------------------------------------------------------------------
@@ -676,6 +723,15 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_new_config_windows_log_max_file_size_none() {
+        let config = Config::new("windows", Some("test/unit/config/windows/log_max_file_size_none.yml"));
+        assert_eq!(config.log_max_file_size, 64);
+    }
+
+    // ------------------------------------------------------------------------
+
     #[cfg(target_os = "linux")]
     #[test]
     fn test_new_config_linux_events_destination() {
@@ -708,6 +764,15 @@ mod tests {
     fn test_new_config_linux_events_max_file_checksum() {
         let config = Config::new("linux", Some("test/unit/config/linux/events_max_file_checksum.yml"));
         assert_eq!(config.events_max_file_checksum, 128);
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_new_config_linux_events_max_file_size() {
+        let config = Config::new("linux", Some("test/unit/config/linux/events_max_file_size.yml"));
+        assert_eq!(config.events_max_file_size, 256);
     }
 
     // ------------------------------------------------------------------------
@@ -851,6 +916,15 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_new_config_linux_log_max_file_size_none() {
+        let config = Config::new("linux", Some("test/unit/config/linux/log_max_file_size_none.yml"));
+        assert_eq!(config.log_max_file_size, 64);
+    }
+
+    // ------------------------------------------------------------------------
+
     #[test]
     fn test_new_config_linux() {
         if utils::get_os() == "linux" {
@@ -868,6 +942,7 @@ mod tests {
             assert_eq!(config.node, String::from("FIM"));
             assert_eq!(config.log_file, String::from("/var/log/fim/fim.log"));
             assert_eq!(config.log_level, String::from("info"));
+            assert_eq!(config.log_max_file_size, 64);
             assert_eq!(config.system, String::from("linux"));
             assert_eq!(config.insecure, false);
         }
@@ -891,6 +966,7 @@ mod tests {
         assert_eq!(config.node, String::from("FIM"));
         assert_eq!(config.log_file, String::from("/var/log/fim/fim.log"));
         assert_eq!(config.log_level, String::from("info"));
+        assert_eq!(config.log_max_file_size, 64);
         assert_eq!(config.system, String::from("macos"));
         assert_eq!(config.insecure, false);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -62,8 +62,8 @@ impl Config {
             path: self.path.clone(),
             events_watcher: self.events_watcher.clone(),
             events_destination: self.events_destination.clone(),
-            events_max_file_checksum: self.events_max_file_checksum.clone(),
-            events_max_file_size: self.events_max_file_size.clone(),
+            events_max_file_checksum: self.events_max_file_checksum,
+            events_max_file_size: self.events_max_file_size,
             endpoint_type: self.endpoint_type.clone(),
             endpoint_address: self.endpoint_address.clone(),
             endpoint_user: self.endpoint_user.clone(),
@@ -75,7 +75,7 @@ impl Config {
             node: self.node.clone(),
             log_file: self.log_file.clone(),
             log_level: self.log_level.clone(),
-            log_max_file_size: self.log_max_file_size.clone(),
+            log_max_file_size: self.log_max_file_size,
             system: self.system.clone(),
             insecure: self.insecure
         }
@@ -128,7 +128,7 @@ impl Config {
         };
 
         // Manage null value on events->max_file_size value
-        let events_max_file_size = match yaml[0]["events"]["events_max_file_size"].as_i64() {
+        let events_max_file_size = match yaml[0]["events"]["max_file_size"].as_i64() {
             Some(value) => usize::try_from(value).unwrap(),
             None => 128
         };
@@ -416,7 +416,7 @@ impl Config {
 
     pub fn get_events_file(&self) -> String {
         unsafe {
-            if TMP_EVENTS == true {
+            if TMP_EVENTS {
                 format!("{}.tmp", self.events_file.clone())
             }else{
                 self.events_file.clone()

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,7 +52,6 @@ pub struct Config {
 }
 
 pub static mut TMP_EVENTS: bool = false;
-pub static mut TMP_LOG: bool = false;
 
 impl Config {
 
@@ -425,8 +424,6 @@ impl Config {
     }
 
 }
-
-
 
 // ----------------------------------------------------------------------------
 
@@ -925,6 +922,7 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_new_config_linux() {
         if utils::get_os() == "linux" {
@@ -950,6 +948,7 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
+    #[cfg(target_os = "macos")]
     #[test]
     fn test_new_config_macos() {
         let config = Config::new("macos", None);
@@ -1118,6 +1117,7 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn test_get_config_path_unix() {
         let current_dir = utils::get_current_dir();

--- a/src/event.rs
+++ b/src/event.rs
@@ -176,13 +176,13 @@ impl Event {
     pub async fn process(&self, destination: &str, index_name: String, config: config::Config){
         match destination {
             config::BOTH_MODE => {
-                self.log(config.events_file);
+                self.log(config.get_events_file());
                 self.send(index_name).await;
             },
             config::NETWORK_MODE => {
                 self.send(index_name).await;
             },
-            _ => self.log(config.events_file)
+            _ => self.log(config.get_events_file())
         }
     }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -300,8 +300,6 @@ mod tests {
     use tokio_test::block_on;
     use std::fs;
 
-    //static mut GCONFIG: Option<config::Config> = None;
-
     // ------------------------------------------------------------------------
 
     fn remove_test_file(filename: String) {

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -41,7 +41,7 @@ pub fn get_checksum(filename: String, read_limit: usize) -> String {
                                 buffer.len()
                             },
                             Err(e) => {
-                                error!("Cannot read file, error: {}", e);
+                                debug!("Cannot read file. Checksum set to 'UNKNOWN', error: {}", e);
                                 0
                             }
                         }

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -35,9 +35,16 @@ pub fn get_checksum(filename: String, read_limit: usize) -> String {
                     }
                     
                     length = {
-                        let buffer = reader.fill_buf().unwrap();
-                        hasher.update(buffer);
-                        buffer.len()
+                        match reader.fill_buf(){
+                            Ok(buffer) =>{
+                                hasher.update(buffer);
+                                buffer.len()
+                            },
+                            Err(e) => {
+                                error!("Cannot read file, error: {}", e);
+                                0
+                            }
+                        }
                     };
                     reader.consume(length);
                     data_read += length / (1024 * 1024);

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -1,15 +1,8 @@
 // Copyright (C) 2023, Achiefs.
 
-// To log the program process
-//use log::{debug, error};
-
-// To get configuration constants
 use crate::config;
-// Single event data management
 use crate::event::Event;
-// Manage integration launch
 use crate::integration;
-// To log the program process
 use log::debug;
 
 // ----------------------------------------------------------------------------
@@ -59,40 +52,22 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
-    pub fn create_test_config(filter: &str, events_destination: &str) -> Config {
-        Config {
-            version: String::from(VERSION),
-            path: String::from("test"),
-            events_watcher: String::from("Recommended"),
-            events_destination: String::from(events_destination),
-            events_max_file_checksum: 64,
-            events_max_file_size: 128,
-            endpoint_type: String::from("Not_defined"),
-            endpoint_address: String::from("test"),
-            endpoint_user: String::from("test"),
-            endpoint_pass: String::from("test"),
-            endpoint_token: String::from("test"),
-            events_file: String::from("test"),
-            monitor: Array::new(),
-            audit: Array::new(),
-            node: String::from("test"),
-            log_file: String::from("./test.log"),
-            log_level: String::from(filter),
-            log_max_file_size: 64,
-            system: String::from("test"),
-            insecure: true
-        }
-    }
-
-    // ------------------------------------------------------------------------
-
+    #[cfg(target_os = "windows")]
     #[test]
     fn test_check_integrations() {
         let event = create_test_event();
-        let config = create_test_config("info", "file");
+        let config = Config::new("windows", Some("test/unit/config/windows/monitor_integration.yml"));
         check_integrations(event, config);
+        
     }
 
     // ------------------------------------------------------------------------
+
+    #[cfg(target_os = "linux")]
+    fn test_check_integrations_linux() {
+        let event = create_test_event();
+        let config = Config::new("linux", Some("test/unit/config/linux/monitor_integration.yml"));
+        check_integrations(event, config);
+    }
 
 }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -66,6 +66,7 @@ mod tests {
             events_watcher: String::from("Recommended"),
             events_destination: String::from(events_destination),
             events_max_file_checksum: 64,
+            events_max_file_size: 128,
             endpoint_type: String::from("Not_defined"),
             endpoint_address: String::from("test"),
             endpoint_user: String::from("test"),
@@ -77,6 +78,7 @@ mod tests {
             node: String::from("test"),
             log_file: String::from("./test.log"),
             log_level: String::from(filter),
+            log_max_file_size: 64,
             system: String::from("test"),
             insecure: true
         }

--- a/src/launcher.rs
+++ b/src/launcher.rs
@@ -64,6 +64,7 @@ mod tests {
     // ------------------------------------------------------------------------
 
     #[cfg(target_os = "linux")]
+    #[test]
     fn test_check_integrations_linux() {
         let event = create_test_event();
         let config = Config::new("linux", Some("test/unit/config/linux/monitor_integration.yml"));

--- a/src/logreader.rs
+++ b/src/logreader.rs
@@ -42,7 +42,7 @@ pub fn read_log(file: String, config: config::Config, position: u64, itx: u64) -
         debug!("Reading start: {}", current_position);
         let bytes_read = match buff.read_line(&mut line){
             Ok(bytes) => {
-                debug!("Read string: '{}', bytes read: {}", line.as_str(), bytes);
+                debug!("Read string: '{}', bytes read: {}", line, bytes);
                 bytes as u64
             },
             Err(e) => {

--- a/src/logreader.rs
+++ b/src/logreader.rs
@@ -42,7 +42,7 @@ pub fn read_log(file: String, config: config::Config, position: u64, itx: u64) -
         debug!("Reading start: {}", current_position);
         let bytes_read = match buff.read_line(&mut line){
             Ok(bytes) => {
-                debug!("Read string: '{}', bytes read: {}", line, bytes);
+                debug!("Read string: '{}', bytes read: {}", line.as_str(), bytes);
                 bytes as u64
             },
             Err(e) => {
@@ -51,7 +51,7 @@ pub fn read_log(file: String, config: config::Config, position: u64, itx: u64) -
             }
         };
         current_position += bytes_read;
-        debug!("End read position: {}", current_position);
+        debug!("End read position: {}\n", current_position);
 
         let line_info = parse_audit_log(line.clone());
         if line_info.contains_key("type") && (line_info["type"] == "SYSCALL" ||
@@ -61,6 +61,7 @@ pub fn read_log(file: String, config: config::Config, position: u64, itx: u64) -
             data.push(line_info.clone());
             if line_info.contains_key("type") &&
                 line_info["type"] == "PROCTITLE" {
+                debug!("PROCTITLE line detected, breaking loop. Data: {:?}", data);
                 break;
             }
         }
@@ -91,6 +92,8 @@ pub fn read_log(file: String, config: config::Config, position: u64, itx: u64) -
             line["type"] == "PROCTITLE"
         }) && itx < 120 {
             current_position = position;
+        }else{
+            debug!("Audit log discarded, data: {:?}", data);
         }
     }
     (event, current_position)

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,11 +3,9 @@
 // To allow big structs like json on audit events
 #![recursion_limit = "256"]
 
-
-// To manage event channels
 use std::sync::mpsc;
-
 use std::thread;
+use log::{error, info};
 
 // Utils functions
 mod utils;
@@ -83,7 +81,11 @@ async fn main() {
     init();
 
     let (tx, rx) = mpsc::channel();
-    thread::spawn(rotator::rotator);
+    match thread::Builder::new()
+        .name("FIM_Rotator".to_string()).spawn(rotator::rotator){
+        Ok(_v) => info!("FIM rotator thread started."),
+        Err(e) => error!("Could not start FIM rotator thread, error: {}", e)
+    };
     monitor::monitor(tx, rx).await;
 }
 
@@ -101,7 +103,11 @@ async fn main() -> windows_service::Result<()> {
         match args[1].as_str() {
             "--foreground"|"-f" => {
                 let (tx, rx) = mpsc::channel();
-                thread::spawn(rotator::rotator);
+                match thread::Builder::new()
+                    .name("FIM_Rotator".to_string()).spawn(rotator::rotator){
+                        Ok(_v) => info!("FIM rotator thread started."),
+                        Err(e) => error!("Could not start FIM rotator thread, error: {}", e)
+                    };
                 monitor::monitor(tx, rx).await;
                 Ok(())
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,8 @@
 // To manage event channels
 use std::sync::mpsc;
 
+use std::thread;
+
 // Utils functions
 mod utils;
 // Hashing functions
@@ -30,6 +32,8 @@ mod integration;
 mod launcher;
 mod multiwatcher;
 
+mod rotator;
+
 static mut GCONFIG: Option<config::Config> = None;
 
 // ----------------------------------------------------------------------------
@@ -40,7 +44,7 @@ fn init(){
     use simplelog::Config;
     use std::fs;
 
-    println!("Achiefs File Integrity Monitoring software starting!");
+    println!("[INFO] Achiefs File Integrity Monitoring software starting!");
     println!("[INFO] Reading config...");
     unsafe{
         GCONFIG = Some(config::Config::new(&utils::get_os(), None));    
@@ -79,6 +83,7 @@ async fn main() {
     init();
 
     let (tx, rx) = mpsc::channel();
+    thread::spawn(|| rotator::rotator());
     monitor::monitor(tx, rx).await;
 }
 
@@ -96,6 +101,7 @@ async fn main() -> windows_service::Result<()> {
         match args[1].as_str() {
             "--foreground"|"-f" => {
                 let (tx, rx) = mpsc::channel();
+                thread::spawn(|| rotator::rotator());
                 monitor::monitor(tx, rx).await;
                 Ok(())
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ async fn main() {
     init();
 
     let (tx, rx) = mpsc::channel();
-    thread::spawn(|| rotator::rotator());
+    thread::spawn(rotator::rotator);
     monitor::monitor(tx, rx).await;
 }
 
@@ -101,7 +101,7 @@ async fn main() -> windows_service::Result<()> {
         match args[1].as_str() {
             "--foreground"|"-f" => {
                 let (tx, rx) = mpsc::channel();
-                thread::spawn(|| rotator::rotator());
+                thread::spawn(rotator::rotator);
                 monitor::monitor(tx, rx).await;
                 Ok(())
             },

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -191,7 +191,6 @@ pub async fn monitor(tx: mpsc::Sender<Result<notify::Event, notify::Error>>,
                     let current_date = OffsetDateTime::now_utc();
                     let index_name = format!("fim-{}-{}-{}", current_date.year(), current_date.month() as u8, current_date.day() );
                     let current_timestamp = format!("{:?}", SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis());
-                    let current_hostname = utils::get_hostname();
                     let kind: notify::EventKind = event.kind;
                     let path = event.paths[0].clone();
 
@@ -204,12 +203,13 @@ pub async fn monitor(tx: mpsc::Sender<Result<notify::Event, notify::Error>>,
                     if plain_path == logreader::AUDIT_LOG_PATH {
                         // Getting events from audit.log
                         let mut events = Vec::new();
-                        let (event, position) = logreader::read_log(String::from(logreader::AUDIT_LOG_PATH), config.clone(), last_position, 0);
-                        if event.id != "0" { events.push(event); };
+                        let (log_event, position) = logreader::read_log(String::from(logreader::AUDIT_LOG_PATH), config.clone(), last_position, 0);
+                        if log_event.id != "0" { events.push(log_event); };
                         let mut ctr = 0;
                         last_position = position;
                         while last_position < utils::get_file_end(logreader::AUDIT_LOG_PATH, 0) {
                             debug!("Reading events, iteration: {}", ctr);
+                            let original_position = last_position;
                             ctr += 1;
                             let (evt, pos) = logreader::read_log(String::from(logreader::AUDIT_LOG_PATH), config.clone(), last_position, ctr);
                             if evt.id != "0" {
@@ -217,6 +217,9 @@ pub async fn monitor(tx: mpsc::Sender<Result<notify::Event, notify::Error>>,
                                 ctr = 0;
                             };
                             last_position = pos;
+                            if original_position == pos {
+                                ctr = 0;
+                            }
                         }
                         debug!("Events read from audit log, position: {}", last_position);
 
@@ -255,7 +258,7 @@ pub async fn monitor(tx: mpsc::Sender<Result<notify::Event, notify::Error>>,
                                 let event = event::Event {
                                     id: utils::get_uuid(),
                                     timestamp: current_timestamp,
-                                    hostname: current_hostname,
+                                    hostname: utils::get_hostname(),
                                     node: config.node.clone(),
                                     version: String::from(config::VERSION),
                                     kind,

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -86,7 +86,7 @@ pub async fn monitor(tx: mpsc::Sender<Result<notify::Event, notify::Error>>,
     if ! config.monitor.is_empty() {
         for element in config.monitor.clone() {
             let path = element["path"].as_str().unwrap();
-            info!("Checking path: {}", path);
+            info!("Monitoring path: {}", path);
 
             match element["ignore"].as_vec() {
                 Some(ig) => {

--- a/src/rotator.rs
+++ b/src/rotator.rs
@@ -15,19 +15,16 @@ fn get_iteration(file: &str) -> u32{
     let mut iteration = 0;
     let mut path = Path::new(file).parent().unwrap().to_path_buf();
     path.push(Path::new("archive"));
-    for entry in path.read_dir().expect("read_dir call failed") {
-        if let Ok(entry) = entry {
-            let path = entry.path();
-            let filename = Path::new(path.file_name().unwrap());
-            let extension = filename.extension().unwrap();
+    for entry in path.read_dir().expect("read_dir call failed").flatten() {
+        let path = entry.path();
+        let filename = Path::new(path.file_name().unwrap());
+        let extension = filename.extension().unwrap();
 
-            if extension.len() == 1 {
-                let int_extension = extension.to_str().unwrap().parse::<u32>().unwrap();
+        if extension.len() == 1 {
+            let int_extension = extension.to_str().unwrap().parse::<u32>().unwrap();
 
-                if int_extension == iteration {
-                    iteration += 1;
-
-                }
+            if int_extension == iteration {
+                iteration += 1;
             }
         }
     }

--- a/src/rotator.rs
+++ b/src/rotator.rs
@@ -1,65 +1,97 @@
 // Copyright (C) 2023, Achiefs.
 
 use std::fs::{metadata, File, copy, read_to_string, remove_file, create_dir};
-use std::io::Write;
+use std::io::{BufReader, BufRead, Write};
 use std::path::Path;
 use std::time::{SystemTime, Duration, UNIX_EPOCH};
 use std::thread;
 use log::{debug, error, info};
 
 use crate::config;
+use crate::utils;
 
 // ----------------------------------------------------------------------------
 
-fn get_iteration(file: &str) -> u32{
-    let mut iteration = 0;
-    let mut path = Path::new(file).parent().unwrap().to_path_buf();
-    path.push(Path::new("archive"));
-    for entry in path.read_dir().expect("read_dir call failed").flatten() {
-        let path = entry.path();
-        let filename = Path::new(path.file_name().unwrap());
-        let extension = filename.extension().unwrap();
+// Compress given file into zip.
+fn compress_file(filepath: &str) -> Result<String, String> {
+    if utils::get_os() == "windows"{
+        use zip::write::FileOptions;
 
-        if extension.len() == 1 {
-            let int_extension = extension.to_str().unwrap().parse::<u32>().unwrap();
+        let filename = Path::new(filepath).file_name().unwrap().to_str().unwrap();
+        let zipfilename = format!("{}.zip", filepath);
+        let path = Path::new(&zipfilename);
+        let zipfile = File::create(path).unwrap();
+    
+        let mut zip = zip::ZipWriter::new(zipfile);
+        match zip.start_file(filename, FileOptions::default()){
+            Ok(_v) => {
+                let file = File::open(filepath).unwrap();
+                let reader = BufReader::new(file);
 
-            if int_extension == iteration {
-                iteration += 1;
+                let mut counter: u64 = 0;
+                let mut broken = false;
+                for line in reader.lines() {
+                    // Sleep during compression to avoid increase CPU load.
+                    if counter == 4096 {
+                        thread::sleep(Duration::from_millis(500));
+                        counter = 0;
+                    }
+                    match zip.write_all(line.unwrap().as_bytes()){
+                        Ok(_v) => debug!("Line written into zip file from rotated file."),
+                        Err(e) => {
+                            error!("Error writting line to zip file, error: {}", e);
+                            broken = true;
+                            break;
+                        }
+                    };
+                    counter += 1;
+                }
+                if ! broken {
+                    match zip.finish(){
+                        Ok(_v) => debug!("File compressed successfully, result: {}", zipfilename),
+                        Err(e) => error!("Error compressing rotated file, error:{}", e)
+                    };
+                }
+                Ok(format!("File {} compressed successfully", filename))
+            },
+            Err(e) => {
+                error!("Could not create file inside zip file, error: {}", e);
+                Err(format!("{}", e))
             }
         }
-    }
-    iteration
+    }else{ Ok(String::from("OK")) }
 }
 
 // ----------------------------------------------------------------------------
 
-fn rotate_file(file: &str, iteration: u32, lock: &mut bool){
-    info!("Rotating {} file...", file);
+fn get_iteration(filepath: &str) -> u32{
+    let mut path = Path::new(filepath).parent().unwrap().to_path_buf();
+    path.push(Path::new("archive"));
+    
+    path.read_dir().expect("read_dir call failed").count() as u32
+}
+
+// ----------------------------------------------------------------------------
+
+fn rotate_file(filepath: &str, iteration: u32, lock: &mut bool){
+    info!("Rotating {} file...", filepath);
     *lock = true;
     thread::sleep(Duration::new(15, 0));
-    let filepath = Path::new(file);
-    let mut parent_path = filepath.parent().unwrap().to_path_buf();
+    let path = Path::new(filepath);
+    let mut parent_path = path.parent().unwrap().to_path_buf();
     parent_path.push(Path::new("archive"));
-    parent_path.push(Path::new(filepath.file_name().unwrap()));
+    parent_path.push(Path::new(path.file_name().unwrap()));
 
     let file_rotated = format!("{}.{}",
         parent_path.to_str().unwrap(), iteration);
-
-    if ! parent_path.parent().unwrap().exists(){
-        match create_dir(parent_path.parent().unwrap()){
-            Ok(_v) => debug!("Archive directory created successfully."),
-            Err(e) => error!("Cannot create archive directory, error: {}", e)
-        };
-    }
     
-
-    match copy(file, file_rotated){
+    match copy(filepath, file_rotated.clone()){
         Ok(_v) => {
             debug!("File copied successfully.");
-            match File::create(file){
+            match File::create(filepath){
                 Ok(truncated_file) => {
                     debug!("File truncated successfully.");
-                    let tmp_file = format!("{}.tmp", file);
+                    let tmp_file = format!("{}.tmp", filepath);
                     let data = match read_to_string(tmp_file.clone()){
                         Ok(read_data) => read_data,
                         Err(_e) => {
@@ -83,9 +115,20 @@ fn rotate_file(file: &str, iteration: u32, lock: &mut bool){
     };
 
     *lock = false;
-    info!("File {} rotated.", file);
+    info!("File {} rotated.", filepath);
+    info!("Compressing rotated file {}", file_rotated);
+    match compress_file(&file_rotated){
+        Ok(message) => {
+            info!("{}", message);
+            match remove_file(file_rotated.clone()) {
+                Ok(_v) => info!("File {} removed.", file_rotated),
+                Err(e) => error!("Cannot remove rotated file, error: {}", e)
+            }
+        },
+        Err(e) => error!("Error compressing file, error: {}", e)
+    };
     
-
+    
 }
 
 // ----------------------------------------------------------------------------
@@ -100,6 +143,17 @@ pub fn rotator(){
             let events_size = metadata(config.clone().events_file).unwrap().len() as usize;
 
             if events_size >= config.events_max_file_size * 1000000 {
+                let events_path = Path::new(config.events_file.as_str());
+                let mut parent_path = events_path.parent().unwrap().to_path_buf();
+                parent_path.push(Path::new("archive"));
+    
+                if ! parent_path.exists(){
+                    match create_dir(parent_path){
+                        Ok(_v) => debug!("Archive directory created successfully."),
+                        Err(e) => error!("Cannot create archive directory, error: {}", e)
+                    };
+                }
+
                 unsafe { rotate_file(config.clone().events_file.as_str(),
                     get_iteration(config.clone().events_file.as_str()), &mut config::TMP_EVENTS) };
             }

--- a/src/rotator.rs
+++ b/src/rotator.rs
@@ -1,0 +1,121 @@
+// Copyright (C) 2023, Achiefs.
+
+use std::fs::{metadata, File, copy, read_to_string, remove_file, create_dir};
+use std::io::Write;
+use std::path::Path;
+use std::time::{SystemTime, Duration, UNIX_EPOCH};
+use std::thread;
+use log::{debug, error, info};
+
+use crate::config;
+
+// ----------------------------------------------------------------------------
+
+fn get_iteration(file: &str) -> u32{
+    let mut iteration = 0;
+    let mut path = Path::new(file).parent().unwrap().to_path_buf();
+    path.push(Path::new("archive"));
+    for entry in path.read_dir().expect("read_dir call failed") {
+        if let Ok(entry) = entry {
+            let path = entry.path();
+            let filename = Path::new(path.file_name().unwrap());
+            let extension = filename.extension().unwrap();
+
+            if extension.len() == 1 {
+                let int_extension = extension.to_str().unwrap().parse::<u32>().unwrap();
+
+                if int_extension == iteration {
+                    iteration += 1;
+
+                }
+            }
+        }
+    }
+    iteration
+}
+
+// ----------------------------------------------------------------------------
+
+fn rotate_file(file: &str, iteration: u32, lock: &mut bool){
+    info!("Rotating {} file...", file);
+    *lock = true;
+    thread::sleep(Duration::new(15, 0));
+    let filepath = Path::new(file);
+    let mut parent_path = filepath.parent().unwrap().to_path_buf();
+    parent_path.push(Path::new("archive"));
+    parent_path.push(Path::new(filepath.file_name().unwrap()));
+
+    let file_rotated = format!("{}.{}",
+        parent_path.to_str().unwrap(), iteration);
+
+    if ! parent_path.parent().unwrap().exists(){
+        match create_dir(parent_path.parent().unwrap()){
+            Ok(_v) => debug!("Archive directory created successfully."),
+            Err(e) => error!("Cannot create archive directory, error: {}", e)
+        };
+    }
+    
+
+    match copy(file, file_rotated){
+        Ok(_v) => {
+            debug!("File copied successfully.");
+            match File::create(file){
+                Ok(truncated_file) => {
+                    debug!("File truncated successfully.");
+                    let tmp_file = format!("{}.tmp", file);
+                    let data = match read_to_string(tmp_file.clone()){
+                        Ok(read_data) => read_data,
+                        Err(_e) => {
+                            debug!("No temporal data to copy.");
+                            String::new()
+                        }
+                    };
+                    match write!(&truncated_file, "{}", data){
+                        Ok(_v) => debug!("Temporal file data written into destination file."),
+                        Err(e) => error!("Cannot write temporal data to destination file skipping, error: {}", e)
+                    };
+                    match remove_file(tmp_file){
+                        Ok(_v) => debug!("Temporal file removed successfully."),
+                        Err(e) => error!("Cannot remove temporal file skipping, error: {}", e)
+                    };
+                },
+                Err(e) => error!("Error truncating file, retrying on next iteration, error: {}", e)
+            };
+        },
+        Err(e) => error!("File cannot be copied, retrying on next iteration, error: {}", e)
+    };
+
+    *lock = false;
+    info!("File {} rotated.", file);
+    
+
+}
+
+// ----------------------------------------------------------------------------
+
+pub fn rotator(){
+    let config = unsafe { super::GCONFIG.clone().unwrap() };
+    let mut start_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+
+    loop{
+        if (start_time + Duration::new(10, 0)).as_millis() < SystemTime::now().duration_since(UNIX_EPOCH).expect("Time went backwards").as_millis() {
+            let log_size = metadata(config.clone().log_file).unwrap().len() as usize;
+            let events_size = metadata(config.clone().events_file).unwrap().len() as usize;
+
+            if events_size >= config.events_max_file_size * 1000000 {
+                unsafe { rotate_file(config.clone().events_file.as_str(),
+                    get_iteration(config.clone().events_file.as_str()), &mut config::TMP_EVENTS) };
+            }
+
+            if log_size >= config.log_max_file_size * 1000000 {
+                unsafe { rotate_file(config.clone().log_file.as_str(),
+                    get_iteration(config.clone().log_file.as_str()), &mut config::TMP_LOG) };
+            }
+
+            start_time = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
+        }
+    }
+}
+
+// ----------------------------------------------------------------------------
+

--- a/src/rotator.rs
+++ b/src/rotator.rs
@@ -14,6 +14,7 @@ use crate::utils;
 
 // Compress given file into zip.
 fn compress_file(filepath: &str) -> Result<String, String> {
+    #[cfg(windows)]
     if utils::get_os() == "windows"{
         use zip::write::FileOptions;
 
@@ -60,6 +61,9 @@ fn compress_file(filepath: &str) -> Result<String, String> {
             }
         }
     }else{ Ok(String::from("OK")) }
+
+    #[cfg(not(windows))]
+    Ok(String::from("OK"))
 }
 
 // ----------------------------------------------------------------------------
@@ -167,6 +171,3 @@ pub fn rotator(){
         }
     }
 }
-
-// ----------------------------------------------------------------------------
-

--- a/src/service.rs
+++ b/src/service.rs
@@ -99,7 +99,7 @@ pub fn run_service() -> Result<()> {
         process_id: None,
     })?;
 
-    thread::spawn(|| rotator::rotator());
+    thread::spawn(rotator::rotator);
     block_on(monitor::monitor(tx, rx));
 
     // Tell the system that service has stopped.

--- a/src/service.rs
+++ b/src/service.rs
@@ -9,7 +9,7 @@ use std::thread;
 use crate::monitor;
 use crate::rotator;
 
-use log::error;
+use log::{error, info};
 use std::{
     ffi::OsString,
     sync::mpsc,
@@ -99,7 +99,11 @@ pub fn run_service() -> Result<()> {
         process_id: None,
     })?;
 
-    thread::spawn(rotator::rotator);
+    match thread::Builder::new()
+        .name("FIM_Rotator".to_string()).spawn(rotator::rotator){
+        Ok(_v) => info!("FIM rotator thread started."),
+        Err(e) => error!("Could not start FIM rotator thread, error: {}", e)
+    };
     block_on(monitor::monitor(tx, rx));
 
     // Tell the system that service has stopped.

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,12 +2,13 @@
 // Parts of the code here is based on mullvad/windows-service-rs crate examples
 // Crate link: https://github.com/mullvad/windows-service-rs
 
-// To manage aynchronous functions
 use futures::executor::block_on;
 use notify::event::{Event, EventKind, EventAttributes};
-// Monitor functions
+use std::thread;
+
 use crate::monitor;
-// To log the program process
+use crate::rotator;
+
 use log::error;
 use std::{
     ffi::OsString,
@@ -98,6 +99,7 @@ pub fn run_service() -> Result<()> {
         process_id: None,
     })?;
 
+    thread::spawn(|| rotator::rotator());
     block_on(monitor::monitor(tx, rx));
 
     // Tell the system that service has stopped.

--- a/test/unit/config/linux/events_max_file_size.yml
+++ b/test/unit/config/linux/events_max_file_size.yml
@@ -1,0 +1,27 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+  max_file_size: 256
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/linux/log_max_file_size_none.yml
+++ b/test/unit/config/linux/log_max_file_size_none.yml
@@ -1,0 +1,25 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]

--- a/test/unit/config/windows/events_max_file_size.yml
+++ b/test/unit/config/windows/events_max_file_size.yml
@@ -1,0 +1,20 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+  max_file_size: 256
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]
+  level: info

--- a/test/unit/config/windows/log_max_file_size_none.yml
+++ b/test/unit/config/windows/log_max_file_size_none.yml
@@ -1,0 +1,18 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: C:\ProgramData\fim\events.json
+
+# Monitor folder or files.
+monitor:
+  - path: C:\Program Files\
+    labels: ["Program Files", "windows"]
+  - path: C:\Users\
+    labels: ["Users", "windows"]
+
+# App procedure and errors logging
+log:
+  file: C:\ProgramData\fim\fim.log
+  # Available levels [debug, info, error, warning]


### PR DESCRIPTION
Hello!

We are glad to include this PR.
It closes #121 and fixes other minor errors.
Tasks:
- Included `rotator` module to check events or log file to rotate.
- Added config parameters `max_file_size` inside events and log sections.
- Bump `reqwest` to 0.11.22.
- Included `zip` crate in Windows and `flate2` and `tar` crate in Linux for file compression.
- Improved `hash` module to manage file fast removal.
- Improved `launcher` module test code.
- Added more debug messages to `logreader` module.
- Fixed monitor error on some specific cases that skip one event.
- Refactor of audit system tests. Now the tests will search the desired event if not found it will assert.

Regards!