### PR TITLE
Hability to exclude folders from recursive monitoring

### DIFF
--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -366,6 +366,15 @@ impl AppConfig {
 
     // ------------------------------------------------------------------------
 
+    pub fn match_exclude(&self, index: usize, path: &str, array: Array) -> bool {
+        match array[index]["exclude"].as_vec() {
+            Some(igv) => igv.to_vec().iter().any(|exclude| path.contains(exclude.as_str().unwrap()) ),
+            None => false
+        }
+    }
+
+    // ------------------------------------------------------------------------
+
     pub fn match_allowed(&self, index: usize, filename: &str, array: Array) -> bool {
         match array[index]["allowed"].as_vec() {
             Some(allowed) => allowed.to_vec().iter().any(|allw| filename.contains(allw.as_str().unwrap())),
@@ -1239,6 +1248,16 @@ mod tests {
             assert!(cfg.match_ignore(0, "file.swp", cfg.audit.clone()));
             assert!(!cfg.match_ignore(0, "file.txt", cfg.audit.clone()));
         }
+    }
+
+    // ------------------------------------------------------------------------
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn test_match_exclude() {
+        let cfg = AppConfig::new(&utils::get_os(), Some("test/unit/config/linux/audit_exclude.yml"));
+        assert!(cfg.match_exclude(0, "/tmp/test", cfg.audit.clone()));
+        assert!(!cfg.match_exclude(0, "/tmp/another", cfg.audit.clone()));
     }
 
     // ------------------------------------------------------------------------

--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -1252,7 +1252,7 @@ mod tests {
 
     // ------------------------------------------------------------------------
 
-    #[cfg(not(target_os = "windows"))]
+    #[cfg(target_os = "linux")]
     #[test]
     fn test_match_exclude() {
         let cfg = AppConfig::new(&utils::get_os(), Some("test/unit/config/linux/audit_exclude.yml"));

--- a/src/monitor.rs
+++ b/src/monitor.rs
@@ -112,8 +112,8 @@ pub async fn monitor(
             };
 
             match element["exclude"].as_vec() {
-                Some(ig) => {
-                    let exclude_vec  = ig.iter().map(|e| e.as_str().unwrap() );
+                Some(ex) => {
+                    let exclude_vec  = ex.iter().map(|e| e.as_str().unwrap() );
                     let exclude_list : String = Itertools::intersperse(exclude_vec, ", ").collect();
                     info!("Excluding folders: '{}' inside '{}' path.", exclude_list, path);
                 },
@@ -124,7 +124,7 @@ pub async fn monitor(
                 Some(allowed) => {
                     let allowed_vec = allowed.iter().map(|e| e.as_str().unwrap());
                     let allowed_list : String = Itertools::intersperse(allowed_vec, ", ").collect();
-                    info!("Only files with '{}' will trigger event inside '{}'.", allowed_list, path)
+                    info!("Only files with '{}' will trigger event inside '{}' path.", allowed_list, path)
                 },
                 None => debug!("Monitoring files under '{}' path.", path)
             }
@@ -147,18 +147,27 @@ pub async fn monitor(
                 Some(allowed) => {
                     let allowed_vec  = allowed.iter().map(|e| e.as_str().unwrap() );
                     let allowed_list : String = Itertools::intersperse(allowed_vec, ", ").collect();
-                    info!("Only files with '{}' will trigger event inside '{}'", allowed_list, path)
+                    info!("Only files with '{}' will trigger event inside '{}' path.", allowed_list, path)
                 },
-                None => debug!("Monitoring all files under this path '{}'", path)
+                None => debug!("Monitoring files under '{}' path.", path)
+            };
+
+            match element["exclude"].as_vec() {
+                Some(ex) => {
+                    let exclude_vec  = ex.iter().map(|e| e.as_str().unwrap() );
+                    let exclude_list : String = Itertools::intersperse(exclude_vec, ", ").collect();
+                    info!("Excluding folders: '{}' inside '{}' path.", exclude_list, path);
+                },
+                None => debug!("Exclude folders for '{}' path not set.", path)
             };
 
             match element["ignore"].as_vec() {
                 Some(ig) => {
                     let ignore_list_vec  = ig.iter().map(|e| e.as_str().unwrap() );
                     let ignore_list : String = Itertools::intersperse(ignore_list_vec, ", ").collect();
-                    info!("Ignoring files with: {} inside {}", ignore_list, path);
+                    info!("Ignoring files with: '{}' inside '{}' path", ignore_list, path);
                 },
-                None => info!("Ignore for '{}' not set", path)
+                None => info!("Ignore for '{}' pat not set", path)
             };
         }
         // Detect if Audit file is moved or renamed (rotation)

--- a/test/unit/config/linux/audit_exclude.yml
+++ b/test/unit/config/linux/audit_exclude.yml
@@ -1,0 +1,27 @@
+node: "FIM"
+
+# Events configuration, where to store produced events
+events:
+  destination: file
+  file: /var/lib/fim/events.json
+
+# Audit extended files and folders information
+audit:
+  - path: /tmp
+    labels: ["tmp", "linux"]
+    ignore: [".swp"]
+    exclude: [ "/tmp/test" ]
+
+# Simple files and folders information
+monitor:
+  - path: /bin/
+  - path: /usr/bin/
+    labels: ["usr/bin", "linux"]
+  - path: /etc
+    labels: ["etc", "linux"]
+
+# App procedure and errors logging
+log:
+  file: /var/log/fim/fim.log
+  # Available levels [debug, info, error, warning]
+  level: info


### PR DESCRIPTION
Hello!

This PR closes #153 , Thanks to @amarce for reporting this.

Features:
- Added `exclude` parameter to audit and monitor fields.
- Added unit tests.