### PR TITLE
Remove LFS repositories

### DIFF
--- a/pkg/deb/repository/release/fim_0.2.0-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.2.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:207083e12c6ceed03f4e683aa1a0e5219fd47c6c4b86c7b688829391386e9600
-size 317172

--- a/pkg/deb/repository/release/fim_0.2.1-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.2.1-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d3689fef6db7f1835d047fb6d1e81c3e65baf67fe967f0d181cfad5a6724e60
-size 323296

--- a/pkg/deb/repository/release/fim_0.3.0-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.3.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fa265a7a5e3f87d6bac82eb07dec7678abe72765b8eed01b1272aa1f45ddad7a
-size 1251600

--- a/pkg/deb/repository/release/fim_0.3.1-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.3.1-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b1121493ca18d0b520a4920d13fa58f1705c87b8350baab8434e7631c9f7445
-size 1253332

--- a/pkg/deb/repository/release/fim_0.3.1-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.3.1-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6655b112cc9d39362f15a75150028b82ddd2953573e3ce6aa61a18dab0e02db
-size 1142708

--- a/pkg/deb/repository/release/fim_0.4.0-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da9979b4c501804d144c279d36f5e06d923b6519d07a2571271b0a5932c38870
-size 1288048

--- a/pkg/deb/repository/release/fim_0.4.0-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.0-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24f4dff9b3b39e46cb9772fd93aa1b1726bbe6c71cff9a9face7c2719be4abaf
-size 1165588

--- a/pkg/deb/repository/release/fim_0.4.1-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.1-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5db05908cebc75af48f828038ebdc84731bb30c879d610adaed9f8c16ff40cca
-size 1298340

--- a/pkg/deb/repository/release/fim_0.4.1-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.1-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15fab646296c659104fd4345265b77f319f6266e3adb0dd4cf55af2cf8ff4c67
-size 1183836

--- a/pkg/deb/repository/release/fim_0.4.10-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.10-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:998f012dab0d3c8c0dfb6aa8fb3af4e4d95e1f36804d6a4ad9f4a84652b5bf41
-size 2030940

--- a/pkg/deb/repository/release/fim_0.4.10-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.10-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2bf9addfb78fdafd7134e1a576ac60dc70bf8f582acec412fe6e5c9750f51588
-size 1791862

--- a/pkg/deb/repository/release/fim_0.4.11-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.11-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c025597773bb699d362c436b81e6909755ed954b5c35d439f9d9031f393f88a8
-size 1950970

--- a/pkg/deb/repository/release/fim_0.4.11-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.11-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76580e3f1a377d9069f3e2b5333b806b035060df702794cf56860e5cf1e2efec
-size 1746656

--- a/pkg/deb/repository/release/fim_0.4.2-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.2-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f14eb01209ea9b968180267bb639f4f9043a95c959c74b331467d043f97edfd0
-size 1303620

--- a/pkg/deb/repository/release/fim_0.4.2-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.2-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c08ca00b637d08bcd8f8c9913ca479cf1a1fd84b7e905e924aa8e4c5bb5c63b4
-size 1191220

--- a/pkg/deb/repository/release/fim_0.4.3-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.3-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1692bf08be7de2350f20f2e96034e507942f8c766bf75035ea16041ce56b5a4e
-size 1811664

--- a/pkg/deb/repository/release/fim_0.4.3-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.3-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74584937394e4cca238d205ff5a014eb817e6c72f204dc1249f91ec2736ffe73
-size 1603296

--- a/pkg/deb/repository/release/fim_0.4.4-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.4-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9abb5450a87b7b8b18395121617483cc9e13f3413f6bd2b1c87948508d8bc44e
-size 1833922

--- a/pkg/deb/repository/release/fim_0.4.4-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.4-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e680d205123dab7cb0f07ef4b29c8cb0123300f35b1c6ae9ae4e1724c0d3a1cc
-size 1616404

--- a/pkg/deb/repository/release/fim_0.4.5-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.5-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9484c8cca6a7b229e35368295ad512d2831ea3d68804e8ce69d096cbda762003
-size 1906952

--- a/pkg/deb/repository/release/fim_0.4.5-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.5-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17b456825910ed5ea2f2699f1e205d063fdac015c404436e4ebd3607e23c369d
-size 1668602

--- a/pkg/deb/repository/release/fim_0.4.6-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.6-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a4d78974b4a1f4af90e35c5e192ff539505db155b24c25ee51225c8817502b3
-size 1894688

--- a/pkg/deb/repository/release/fim_0.4.6-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.6-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2607de8a5d4358040310aa43cd1d49213091363c40c87b27fb7266e2ae69cdc7
-size 1670470

--- a/pkg/deb/repository/release/fim_0.4.7-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.7-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:626b40714aff47227dc6e401263d5d1d3677e341761346a9e85f4fd2017f6428
-size 1920726

--- a/pkg/deb/repository/release/fim_0.4.7-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.7-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6581f5dbc721f4d5be7ab6c4ec0610c26aace843d497f66a282e664ec37045c2
-size 1671628

--- a/pkg/deb/repository/release/fim_0.4.8-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.8-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d058b9335c594ad23c74744412b68aa188f6aaac755ab328fd570e484d7dd56
-size 1959598

--- a/pkg/deb/repository/release/fim_0.4.8-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.8-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3702c0ee72a07157d05dde7d480fda78f78bb88651464df405b64e70746c3007
-size 1745022

--- a/pkg/deb/repository/release/fim_0.4.9-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.4.9-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f15d19ee1b7275e2ee2848d858a791bffed01a247674510d094d1e5098798491
-size 1999450

--- a/pkg/deb/repository/release/fim_0.4.9-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.4.9-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:231ec7f4df51d33d971c946d0f2b97104c12a640f1360022f01ff8e2d32d60a9
-size 1776582

--- a/pkg/deb/repository/release/fim_0.5.0-1_amd64.deb
+++ b/pkg/deb/repository/release/fim_0.5.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7675f8ead3cc37d7606b8fb52e7f5a8c96019c605c44eb0504727589de9d5bf
-size 1805486

--- a/pkg/deb/repository/release/fim_0.5.0-1_arm64.deb
+++ b/pkg/deb/repository/release/fim_0.5.0-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e57748135580afbe712fccfa8c758af53aa78d2c98e359c968af311d6ab52959
-size 1609050

--- a/pkg/deb/repository/test/fim_0.2.0-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.2.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:207083e12c6ceed03f4e683aa1a0e5219fd47c6c4b86c7b688829391386e9600
-size 317172

--- a/pkg/deb/repository/test/fim_0.2.1-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.2.1-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0d3689fef6db7f1835d047fb6d1e81c3e65baf67fe967f0d181cfad5a6724e60
-size 323296

--- a/pkg/deb/repository/test/fim_0.3.0-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.3.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:91b6a0e521a322a9cea77c2b9386f70fe895900767a4da13193572e097351a99
-size 1202896

--- a/pkg/deb/repository/test/fim_0.3.1-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.3.1-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b1121493ca18d0b520a4920d13fa58f1705c87b8350baab8434e7631c9f7445
-size 1253332

--- a/pkg/deb/repository/test/fim_0.3.1-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.3.1-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d6655b112cc9d39362f15a75150028b82ddd2953573e3ce6aa61a18dab0e02db
-size 1142708

--- a/pkg/deb/repository/test/fim_0.4.0-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:da9979b4c501804d144c279d36f5e06d923b6519d07a2571271b0a5932c38870
-size 1288048

--- a/pkg/deb/repository/test/fim_0.4.0-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.0-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:24f4dff9b3b39e46cb9772fd93aa1b1726bbe6c71cff9a9face7c2719be4abaf
-size 1165588

--- a/pkg/deb/repository/test/fim_0.4.1-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.1-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5db05908cebc75af48f828038ebdc84731bb30c879d610adaed9f8c16ff40cca
-size 1298340

--- a/pkg/deb/repository/test/fim_0.4.1-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.1-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:15fab646296c659104fd4345265b77f319f6266e3adb0dd4cf55af2cf8ff4c67
-size 1183836

--- a/pkg/deb/repository/test/fim_0.4.10-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.10-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:998f012dab0d3c8c0dfb6aa8fb3af4e4d95e1f36804d6a4ad9f4a84652b5bf41
-size 2030940

--- a/pkg/deb/repository/test/fim_0.4.10-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.10-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2bf9addfb78fdafd7134e1a576ac60dc70bf8f582acec412fe6e5c9750f51588
-size 1791862

--- a/pkg/deb/repository/test/fim_0.4.11-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.11-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c025597773bb699d362c436b81e6909755ed954b5c35d439f9d9031f393f88a8
-size 1950970

--- a/pkg/deb/repository/test/fim_0.4.11-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.11-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:76580e3f1a377d9069f3e2b5333b806b035060df702794cf56860e5cf1e2efec
-size 1746656

--- a/pkg/deb/repository/test/fim_0.4.2-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.2-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f14eb01209ea9b968180267bb639f4f9043a95c959c74b331467d043f97edfd0
-size 1303620

--- a/pkg/deb/repository/test/fim_0.4.2-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.2-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c08ca00b637d08bcd8f8c9913ca479cf1a1fd84b7e905e924aa8e4c5bb5c63b4
-size 1191220

--- a/pkg/deb/repository/test/fim_0.4.3-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.3-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1692bf08be7de2350f20f2e96034e507942f8c766bf75035ea16041ce56b5a4e
-size 1811664

--- a/pkg/deb/repository/test/fim_0.4.3-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.3-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:74584937394e4cca238d205ff5a014eb817e6c72f204dc1249f91ec2736ffe73
-size 1603296

--- a/pkg/deb/repository/test/fim_0.4.4-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.4-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9abb5450a87b7b8b18395121617483cc9e13f3413f6bd2b1c87948508d8bc44e
-size 1833922

--- a/pkg/deb/repository/test/fim_0.4.4-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.4-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e680d205123dab7cb0f07ef4b29c8cb0123300f35b1c6ae9ae4e1724c0d3a1cc
-size 1616404

--- a/pkg/deb/repository/test/fim_0.4.5-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.5-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9484c8cca6a7b229e35368295ad512d2831ea3d68804e8ce69d096cbda762003
-size 1906952

--- a/pkg/deb/repository/test/fim_0.4.5-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.5-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:17b456825910ed5ea2f2699f1e205d063fdac015c404436e4ebd3607e23c369d
-size 1668602

--- a/pkg/deb/repository/test/fim_0.4.6-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.6-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2a4d78974b4a1f4af90e35c5e192ff539505db155b24c25ee51225c8817502b3
-size 1894688

--- a/pkg/deb/repository/test/fim_0.4.6-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.6-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2607de8a5d4358040310aa43cd1d49213091363c40c87b27fb7266e2ae69cdc7
-size 1670470

--- a/pkg/deb/repository/test/fim_0.4.7-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.7-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:626b40714aff47227dc6e401263d5d1d3677e341761346a9e85f4fd2017f6428
-size 1920726

--- a/pkg/deb/repository/test/fim_0.4.7-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.7-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6581f5dbc721f4d5be7ab6c4ec0610c26aace843d497f66a282e664ec37045c2
-size 1671628

--- a/pkg/deb/repository/test/fim_0.4.8-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.8-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2d058b9335c594ad23c74744412b68aa188f6aaac755ab328fd570e484d7dd56
-size 1959598

--- a/pkg/deb/repository/test/fim_0.4.8-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.8-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:3702c0ee72a07157d05dde7d480fda78f78bb88651464df405b64e70746c3007
-size 1745022

--- a/pkg/deb/repository/test/fim_0.4.9-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.4.9-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f15d19ee1b7275e2ee2848d858a791bffed01a247674510d094d1e5098798491
-size 1999450

--- a/pkg/deb/repository/test/fim_0.4.9-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.4.9-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:231ec7f4df51d33d971c946d0f2b97104c12a640f1360022f01ff8e2d32d60a9
-size 1776582

--- a/pkg/deb/repository/test/fim_0.5.0-1_amd64.deb
+++ b/pkg/deb/repository/test/fim_0.5.0-1_amd64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d7675f8ead3cc37d7606b8fb52e7f5a8c96019c605c44eb0504727589de9d5bf
-size 1805486

--- a/pkg/deb/repository/test/fim_0.5.0-1_arm64.deb
+++ b/pkg/deb/repository/test/fim_0.5.0-1_arm64.deb
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e57748135580afbe712fccfa8c758af53aa78d2c98e359c968af311d6ab52959
-size 1609050

--- a/pkg/macos/repository/fim-0.4.10-arm64.pkg
+++ b/pkg/macos/repository/fim-0.4.10-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:adf5adc51aefd8d779b14398b3a07f2960c35d7ac9e45220665a9444a9e88082
-size 2957717

--- a/pkg/macos/repository/fim-0.4.10-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.4.10-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9deb907c1b6e4e700faff269b89f9355f72166d4034ef268415881fd7b113143
-size 3007861

--- a/pkg/macos/repository/fim-0.4.11-arm64.pkg
+++ b/pkg/macos/repository/fim-0.4.11-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7255b4ba915ba91e794891a25dc314290525e810e3410853c78d0c65f6e24a0
-size 2957107

--- a/pkg/macos/repository/fim-0.4.11-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.4.11-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:804ae125c503e6c8fea4f7b57be7f2f7a7039024d18e5ace72c3425f30b39c86
-size 3007868

--- a/pkg/macos/repository/fim-0.4.6-arm64.pkg
+++ b/pkg/macos/repository/fim-0.4.6-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:34334ccf1fb7a7113ebe506db868dc946be79e09f3181c80654f8ce657892d89
-size 2775221

--- a/pkg/macos/repository/fim-0.4.6-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.4.6-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1a3e694284547d3ee95979071e0ac9b14829456bf7efb3b9630123ec1c6f804f
-size 2868609

--- a/pkg/macos/repository/fim-0.4.7-arm64.pkg
+++ b/pkg/macos/repository/fim-0.4.7-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d9a7e2f225918b335ffb1abca63153929d3eb5426bce5f82faffc0e8cfc6598a
-size 2810601

--- a/pkg/macos/repository/fim-0.4.7-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.4.7-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:517c5b0c049b8334ac7fd8601edbafc06c2ef1225e33cfa09dcca3d006bdd5f1
-size 2905464

--- a/pkg/macos/repository/fim-0.4.8-arm64.pkg
+++ b/pkg/macos/repository/fim-0.4.8-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d01066d8d42d055571d5a1f7d9358a8eaf3cd159678f3b8836c7994087dea7e3
-size 2839221

--- a/pkg/macos/repository/fim-0.4.8-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.4.8-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c93ca594c877ceab693bffbff5197f221cb922eab0ec8aab21b6974bf70fdd68
-size 2938235

--- a/pkg/macos/repository/fim-0.4.9-arm64.pkg
+++ b/pkg/macos/repository/fim-0.4.9-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:71dba4bca8a65ad349511d63fd69db6cd80022cd3d216b8c4b7b343a98876279
-size 2958941

--- a/pkg/macos/repository/fim-0.4.9-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.4.9-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e4a41d17e29c882167c321edcec965a506a44e5e799eb00096028731e56fe30a
-size 3007862

--- a/pkg/macos/repository/fim-0.5.0-arm64.pkg
+++ b/pkg/macos/repository/fim-0.5.0-arm64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6e147c880cd92f8e9ff559c80ffddfbb4124b5f2702c007ea092b0c19e7d76ea
-size 2532912

--- a/pkg/macos/repository/fim-0.5.0-x86_64.pkg
+++ b/pkg/macos/repository/fim-0.5.0-x86_64.pkg
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:33058c4196ad0427f3677f781ed7c94529782f635bef789b07cbe9319094cc9b
-size 2651529

--- a/pkg/msi/repository/fim-0.4.1-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.1-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:57aec62bf5fe6906ca5ae771faf7c918f4b6e5a90a9d489ec86fe0606bcf8c8f
-size 1585152

--- a/pkg/msi/repository/fim-0.4.10-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.10-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:8812e90d953c01edfaa526224e0e937db3835d0728efd210bce278a9249dae19
-size 2473984

--- a/pkg/msi/repository/fim-0.4.11-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.11-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ee9279722619d44c9d0eb23e11d15e43006f68177439e85be8038b39ddf714a2
-size 2473984

--- a/pkg/msi/repository/fim-0.4.2-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.2-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:ec712e2105831c1d9aef4a95575ee86c42c7375ea156e48a4b3e9927c3681d09
-size 1585152

--- a/pkg/msi/repository/fim-0.4.3-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.3-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a581d3cf12f37159264973a4231081667e4b98e0c7ccd0da66b24e458c68733f
-size 2056192

--- a/pkg/msi/repository/fim-0.4.4-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.4-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:819379bd179c194fe7fc3f6b9d9f844f49d13439e5b024392966f48f074ed351
-size 2056192

--- a/pkg/msi/repository/fim-0.4.5-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.5-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e737378ee873a41ae73d55e9908e089fde609b2272b30e0c9e31debb5d1aad26
-size 2072576

--- a/pkg/msi/repository/fim-0.4.6-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.6-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d46b0a0757ba8b182e0a991325623d1885d7545b13b044f97f1461865bed0e5b
-size 2203648

--- a/pkg/msi/repository/fim-0.4.7-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.7-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c18e119a54c6431e4fc063cfdb03f20dbfbc2dac967fb0bdd94905ec39d58183
-size 2236416

--- a/pkg/msi/repository/fim-0.4.8-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.8-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:49074aed082fc3e120a3d188a0a0f180e88dd3f9dc0c3a0e027f9149d8da2e08
-size 2248704

--- a/pkg/msi/repository/fim-0.4.9-1-x64.msi
+++ b/pkg/msi/repository/fim-0.4.9-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:245a224974359802dd5fcd166dd5bc4f25e2403a23bb4fd157f0a6761ba72e55
-size 2248704

--- a/pkg/msi/repository/fim-0.5.0-1-x64.msi
+++ b/pkg/msi/repository/fim-0.5.0-1-x64.msi
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:037a6437750daa28533a4927e93b896e3eb61765359552cf283b9ab1526e5a4c
-size 2371584

--- a/pkg/rpm/repository/release/fim-0.2.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.2.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80ce5a71ca8422301660eac79e42fc566990ea7cfebda6f4d9ace27fc4c55ba7
-size 408252

--- a/pkg/rpm/repository/release/fim-0.2.1-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.2.1-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5976ac04da47fd7f2927892bcf750b70da9365fabbab472de4a2d90a98d9bfc
-size 1027260

--- a/pkg/rpm/repository/release/fim-0.3.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.3.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c87a0a8831dc470481fdee2aec38fb51d1a81b841b6eadc98e1ddf6503330004
-size 2376796

--- a/pkg/rpm/repository/release/fim-0.3.1-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.3.1-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37219eb46707e71c746500e08f6986c67c9a305207413485c15f9415c9fa4014
-size 2300836

--- a/pkg/rpm/repository/release/fim-0.3.1-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.3.1-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fb15c1be277669e7c595732ba56e2e30d66ed13873d63dd636dbceb34f43f4d
-size 2385972

--- a/pkg/rpm/repository/release/fim-0.4.0-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.0-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dce02aeab07cbcdab385c4cd8f243abcf98953dca2dabf41829f9144ac7c8d2
-size 2329716

--- a/pkg/rpm/repository/release/fim-0.4.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6522c8b69ec032a5ba610b5fcb48ddbd99e4ce593843f48d94519c8e9786b86f
-size 2424540

--- a/pkg/rpm/repository/release/fim-0.4.1-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.1-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a333a789af3f1b62c1efd19a09d57241d8f884661c4173dc5ca4ed89c64ab75e
-size 2374256

--- a/pkg/rpm/repository/release/fim-0.4.1-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.1-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86eb75bcf22486fd90e1a0b2bed2b53190f108113b7bff69640bb37406363b92
-size 2456956

--- a/pkg/rpm/repository/release/fim-0.4.10-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.10-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0b110e0f15e9c7a3113496e1f330fdd113c1f945f5bbe62755d173dd54e78b8
-size 2439984

--- a/pkg/rpm/repository/release/fim-0.4.10-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.10-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ddf751d4daa751aa536eb461396e220a3c792e71c9060e9e2aa4cff16708a8e
-size 3799584

--- a/pkg/rpm/repository/release/fim-0.4.11-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.11-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43d4493621c5709265a2602bb15b08178c4b73ba3f435dac8dd9ed0c4b4560f4
-size 2302160

--- a/pkg/rpm/repository/release/fim-0.4.11-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.11-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f04b8b058a436f71ceed67c91ee4a7af11e091149c4ab6c55e503e8eda5f4072
-size 2447392

--- a/pkg/rpm/repository/release/fim-0.4.2-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.2-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f11f67b3bb6e90ee1e1ef3671ee434160d6cd87286da6dfc648d8ba9fc571b25
-size 2402000

--- a/pkg/rpm/repository/release/fim-0.4.2-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.2-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97b67d260d6ad2b7f45653925352666c42b3d0e03e6b0e2d7de757314e716251
-size 2481504

--- a/pkg/rpm/repository/release/fim-0.4.3-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.3-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:405a0b634ebe3be4e9277769d08a2947c71ea0823471c8b34148cb7357785953
-size 3003312

--- a/pkg/rpm/repository/release/fim-0.4.3-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.3-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:742d97041e7bbccafec712f8a65fbef5550a823283af56b23a759f84c248e709
-size 3210528

--- a/pkg/rpm/repository/release/fim-0.4.4-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.4-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8f4e1261c8a9013d66c34d0789199674ed16ad606e22dd9b584408ae1ecc75b
-size 3012488

--- a/pkg/rpm/repository/release/fim-0.4.4-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.4-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb33a8cd7ac541d8320f21737cd845cad30441a0587d5f9f9a9ae2d5b3b51e3f
-size 3224472

--- a/pkg/rpm/repository/release/fim-0.4.5-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.5-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc7ab46e211a712b1b646877fff87f182876d666c4d3e9bdaa6ca63134be06f4
-size 3095504

--- a/pkg/rpm/repository/release/fim-0.4.5-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.5-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06e133d0f12372281bf45aa33444b035e9d134186c049bafc6f5a9f621847d7b
-size 3334640

--- a/pkg/rpm/repository/release/fim-0.4.6-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.6-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88a518abc7ced2be9b900f6b63c3d0e3d231a629988ccc08f3c1d74dd704c6f2
-size 3104336

--- a/pkg/rpm/repository/release/fim-0.4.6-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.6-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c9503d59e0eb83d94ef2b05f3b38b2e5bdb1c8ba9418ee1b3ed941978455516
-size 3332916

--- a/pkg/rpm/repository/release/fim-0.4.7-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.7-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:890c761a31510daa270c3f0ef593ea80a780ccc17de375cec64d430bc523b6e2
-size 3110824

--- a/pkg/rpm/repository/release/fim-0.4.7-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.7-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d70306b750c59d53bb51b43af38e24336a1b8a30c69022e8c43aac4a012e25e5
-size 3362072

--- a/pkg/rpm/repository/release/fim-0.4.8-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.8-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e9e46d2908e14027fdf624a0294db2e7ae27ab72a9f1f2718646873514d7fd8
-size 3221892

--- a/pkg/rpm/repository/release/fim-0.4.8-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.8-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c31c9ee3c61f3e07ba12c0f069d634062cc8c23ef1f6307452bd0b8f9d23792
-size 3439508

--- a/pkg/rpm/repository/release/fim-0.4.9-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.9-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7759c53f7f3f2f607ee27fbf95e2e470dc1433c43f0f0a976695fdc92b897fd8
-size 3281608

--- a/pkg/rpm/repository/release/fim-0.4.9-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.4.9-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81b9c983cc2f82004fd46973928c148f2550bb6ef57e750832ac1c1790748048
-size 3505012

--- a/pkg/rpm/repository/release/fim-0.5.0-1.aarch64.rpm
+++ b/pkg/rpm/repository/release/fim-0.5.0-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b4d19777c5f3acfc503d88ce3abb0c81ce5a057be048ce5df3b95e1b8137f21
-size 2118604

--- a/pkg/rpm/repository/release/fim-0.5.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/release/fim-0.5.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b55d3843f287b7766bcb1b1a0119c9008c2bf276c98e733f966202bf8b673f73
-size 2261484

--- a/pkg/rpm/repository/test/fim-0.2.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.2.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:80ce5a71ca8422301660eac79e42fc566990ea7cfebda6f4d9ace27fc4c55ba7
-size 408252

--- a/pkg/rpm/repository/test/fim-0.2.1-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.2.1-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:e5976ac04da47fd7f2927892bcf750b70da9365fabbab472de4a2d90a98d9bfc
-size 1027260

--- a/pkg/rpm/repository/test/fim-0.3.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.3.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:304e0a30721029b28b90653f7b2b2b0ce9949ab85d33a5dc56521e4b62635887
-size 2271960

--- a/pkg/rpm/repository/test/fim-0.3.1-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.3.1-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:37219eb46707e71c746500e08f6986c67c9a305207413485c15f9415c9fa4014
-size 2300836

--- a/pkg/rpm/repository/test/fim-0.3.1-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.3.1-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:5fb15c1be277669e7c595732ba56e2e30d66ed13873d63dd636dbceb34f43f4d
-size 2385972

--- a/pkg/rpm/repository/test/fim-0.4.0-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.0-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dce02aeab07cbcdab385c4cd8f243abcf98953dca2dabf41829f9144ac7c8d2
-size 2329716

--- a/pkg/rpm/repository/test/fim-0.4.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6522c8b69ec032a5ba610b5fcb48ddbd99e4ce593843f48d94519c8e9786b86f
-size 2424540

--- a/pkg/rpm/repository/test/fim-0.4.1-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.1-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:a333a789af3f1b62c1efd19a09d57241d8f884661c4173dc5ca4ed89c64ab75e
-size 2374256

--- a/pkg/rpm/repository/test/fim-0.4.1-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.1-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:86eb75bcf22486fd90e1a0b2bed2b53190f108113b7bff69640bb37406363b92
-size 2456956

--- a/pkg/rpm/repository/test/fim-0.4.10-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.10-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b0b110e0f15e9c7a3113496e1f330fdd113c1f945f5bbe62755d173dd54e78b8
-size 2439984

--- a/pkg/rpm/repository/test/fim-0.4.10-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.10-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:1ddf751d4daa751aa536eb461396e220a3c792e71c9060e9e2aa4cff16708a8e
-size 3799584

--- a/pkg/rpm/repository/test/fim-0.4.11-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.11-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:43d4493621c5709265a2602bb15b08178c4b73ba3f435dac8dd9ed0c4b4560f4
-size 2302160

--- a/pkg/rpm/repository/test/fim-0.4.11-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.11-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f04b8b058a436f71ceed67c91ee4a7af11e091149c4ab6c55e503e8eda5f4072
-size 2447392

--- a/pkg/rpm/repository/test/fim-0.4.2-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.2-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f11f67b3bb6e90ee1e1ef3671ee434160d6cd87286da6dfc648d8ba9fc571b25
-size 2402000

--- a/pkg/rpm/repository/test/fim-0.4.2-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.2-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:97b67d260d6ad2b7f45653925352666c42b3d0e03e6b0e2d7de757314e716251
-size 2481504

--- a/pkg/rpm/repository/test/fim-0.4.3-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.3-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:405a0b634ebe3be4e9277769d08a2947c71ea0823471c8b34148cb7357785953
-size 3003312

--- a/pkg/rpm/repository/test/fim-0.4.3-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.3-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:742d97041e7bbccafec712f8a65fbef5550a823283af56b23a759f84c248e709
-size 3210528

--- a/pkg/rpm/repository/test/fim-0.4.4-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.4-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:c8f4e1261c8a9013d66c34d0789199674ed16ad606e22dd9b584408ae1ecc75b
-size 3012488

--- a/pkg/rpm/repository/test/fim-0.4.4-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.4-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:fb33a8cd7ac541d8320f21737cd845cad30441a0587d5f9f9a9ae2d5b3b51e3f
-size 3224472

--- a/pkg/rpm/repository/test/fim-0.4.5-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.5-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:dc7ab46e211a712b1b646877fff87f182876d666c4d3e9bdaa6ca63134be06f4
-size 3095504

--- a/pkg/rpm/repository/test/fim-0.4.5-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.5-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:06e133d0f12372281bf45aa33444b035e9d134186c049bafc6f5a9f621847d7b
-size 3334640

--- a/pkg/rpm/repository/test/fim-0.4.6-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.6-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:88a518abc7ced2be9b900f6b63c3d0e3d231a629988ccc08f3c1d74dd704c6f2
-size 3104336

--- a/pkg/rpm/repository/test/fim-0.4.6-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.6-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7c9503d59e0eb83d94ef2b05f3b38b2e5bdb1c8ba9418ee1b3ed941978455516
-size 3332916

--- a/pkg/rpm/repository/test/fim-0.4.7-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.7-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:890c761a31510daa270c3f0ef593ea80a780ccc17de375cec64d430bc523b6e2
-size 3110824

--- a/pkg/rpm/repository/test/fim-0.4.7-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.7-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:d70306b750c59d53bb51b43af38e24336a1b8a30c69022e8c43aac4a012e25e5
-size 3362072

--- a/pkg/rpm/repository/test/fim-0.4.8-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.8-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7e9e46d2908e14027fdf624a0294db2e7ae27ab72a9f1f2718646873514d7fd8
-size 3221892

--- a/pkg/rpm/repository/test/fim-0.4.8-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.8-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6c31c9ee3c61f3e07ba12c0f069d634062cc8c23ef1f6307452bd0b8f9d23792
-size 3439508

--- a/pkg/rpm/repository/test/fim-0.4.9-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.9-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:7759c53f7f3f2f607ee27fbf95e2e470dc1433c43f0f0a976695fdc92b897fd8
-size 3281608

--- a/pkg/rpm/repository/test/fim-0.4.9-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.4.9-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:81b9c983cc2f82004fd46973928c148f2550bb6ef57e750832ac1c1790748048
-size 3505012

--- a/pkg/rpm/repository/test/fim-0.5.0-1.aarch64.rpm
+++ b/pkg/rpm/repository/test/fim-0.5.0-1.aarch64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0b4d19777c5f3acfc503d88ce3abb0c81ce5a057be048ce5df3b95e1b8137f21
-size 2118604

--- a/pkg/rpm/repository/test/fim-0.5.0-1.x86_64.rpm
+++ b/pkg/rpm/repository/test/fim-0.5.0-1.x86_64.rpm
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:b55d3843f287b7766bcb1b1a0119c9008c2bf276c98e733f966202bf8b673f73
-size 2261484


### PR DESCRIPTION
Hello!

I have facing some issues with GitHub LFS file storage over the quota, so I decided to only left the packages in the releases section. Maybe I found another way to store the packages in a better way.