### PR TITLE
Fix indexer template installation on MSI package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fim"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["José Fernández <´pylott@gmail.com´>"]
 edition = "2021"
 

--- a/pkg/deb/debian/changelog
+++ b/pkg/deb/debian/changelog
@@ -1,3 +1,9 @@
+fim (0.5.1-1) xenial; urgency=medium
+
+  * More info: https://github.com/Achiefs/fim/releases/tag/v0.5.1
+
+ -- Jose Fernandez <support@achiefs.com>  Thu, 10 Oct 2024 20:32:00 +0000
+
 fim (0.5.0-1) xenial; urgency=medium
 
   * More info: https://github.com/Achiefs/fim/releases/tag/v0.5.0

--- a/pkg/msi/builder.ps1
+++ b/pkg/msi/builder.ps1
@@ -8,6 +8,7 @@ cd pkg\msi
 
 cp ..\..\target\release\fim.exe .\
 cp ..\..\config\windows\config.yml .\
+cp ..\..\config\index_template.json .\
 cp ..\..\config\windows\rules.yml .\
 
 Invoke-Expression "& `"C:\Program Files (x86)\WiX Toolset v3.*\bin\candle.exe`" .\fim.wxs -o .\fim.wixobj"

--- a/pkg/msi/fim.wxs
+++ b/pkg/msi/fim.wxs
@@ -33,7 +33,7 @@ https://github.com/Achiefs/fim/wiki" />
                         <File Id='CONFIG' Name='config.yml' DiskId='1' Source='config.yml' KeyPath='yes'></File>
                     </Component>
                     <Component Id='IndexTemplateFile' Guid='*' Win64="yes">
-                        <File Id='CONFIG' Name='index_template.json' DiskId='1' Source='index_template.json' KeyPath='yes'></File>
+                        <File Id='INDEXTEMPLATE' Name='index_template.json' DiskId='1' Source='index_template.json' KeyPath='yes'></File>
                     </Component>
                     <Component Id='RulesFile' Guid='*' Win64="yes">
                         <File Id='RULES' Name='rules.yml' DiskId='1' Source='rules.yml' KeyPath='yes'></File>

--- a/pkg/msi/fim.wxs
+++ b/pkg/msi/fim.wxs
@@ -32,6 +32,9 @@ https://github.com/Achiefs/fim/wiki" />
                     <Component Id='ConfigFile' Guid='*' Win64="yes">
                         <File Id='CONFIG' Name='config.yml' DiskId='1' Source='config.yml' KeyPath='yes'></File>
                     </Component>
+                    <Component Id='IndexTemplateFile' Guid='*' Win64="yes">
+                        <File Id='CONFIG' Name='index_template.json' DiskId='1' Source='index_template.json' KeyPath='yes'></File>
+                    </Component>
                     <Component Id='RulesFile' Guid='*' Win64="yes">
                         <File Id='RULES' Name='rules.yml' DiskId='1' Source='rules.yml' KeyPath='yes'></File>
                     </Component>
@@ -44,6 +47,7 @@ https://github.com/Achiefs/fim/wiki" />
             <Feature Id='MainProgram' Title='Program' Description='The main executable.' Level='1'>
                 <ComponentRef Id='MainExecutable' />
                 <ComponentRef Id='ConfigFile' />
+                <ComponentRef Id='IndexTemplateFile' />
                 <ComponentRef Id='RulesFile' />
             </Feature>
         </Feature>

--- a/pkg/rpm/fim.spec
+++ b/pkg/rpm/fim.spec
@@ -101,6 +101,9 @@ rm -fr %{buildroot}
 # -----------------------------------------------------------------------------
 
 %changelog
+* Thu Oct 10 2024 support <support@achiefs.com> - 0.5.1
+- More info: https://github.com/Achiefs/fim/releases/tag/v0.5.1
+
 * Tue Apr 30 2024 support <support@achiefs.com> - 0.5.0
 - More info: https://github.com/Achiefs/fim/releases/tag/v0.5.0
 

--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2021, Achiefs.
 
 // Global constants definitions
-pub const VERSION: &str = "0.5.0";
+pub const VERSION: &str = "0.5.1";
 pub const NETWORK_MODE: &str = "NETWORK";
 pub const FILE_MODE: &str = "FILE";
 pub const BOTH_MODE: &str = "BOTH";

--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -211,7 +211,7 @@ impl AppConfig {
         // Manage null value on audit value
         let audit = match yaml[0]["audit"].as_vec() {
             Some(value) => {
-                if utils::get_os() != "linux"{
+                if utils::get_os() != "linux" {
                     panic!("Audit only supported in Linux systems.");
                 }
                 value.to_vec()

--- a/src/index.rs
+++ b/src/index.rs
@@ -31,12 +31,10 @@ fn get_template_path() -> String {
         String::from(relative_path)
     }else if Path::new(config_path).exists() {
         String::from(config_path)
+    }else if utils::get_os() != "windows" {
+        format!("{}/{}", executable_path.clone().parent().unwrap().to_str().unwrap(), "index_template.json")
     }else{
-        if utils::get_os() != "windows"{
-            format!("{}/{}", executable_path.clone().parent().unwrap().to_str().unwrap(), "index_template.json")
-        }else{
-            format!("{}\\{}", executable_path.clone().parent().unwrap().to_str().unwrap(), "index_template.json")
-        }
+        format!("{}\\{}", executable_path.clone().parent().unwrap().to_str().unwrap(), "index_template.json")
     }
 }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -12,21 +12,31 @@ use log::{info, debug, error};
 use std::path::Path;
 // Handle time intervals
 use std::time::Duration;
+use std::env;
 
 use crate::appconfig::*;
+use crate::utils;
 
 fn get_template_path() -> String {
     let relative_path = "./../../config/index_template.json";
     let config_path = "/etc/fim/index_template.json";
     let default_path = "config/index_template.json";
+    let executable_path = env::current_exe().unwrap();
+    
     if Path::new(default_path).exists() {
         String::from(default_path)
     }else if Path::new("./index_template.json").exists() {
         String::from("./index_template.json")
     }else if Path::new(relative_path).exists() {
         String::from(relative_path)
-    }else{
+    }else if Path::new(config_path).exists() {
         String::from(config_path)
+    }else{
+        if utils::get_os() != "windows"{
+            format!("{}/{}", executable_path.clone().parent().unwrap().to_str().unwrap(), "index_template.json")
+        }else{
+            format!("{}\\{}", executable_path.clone().parent().unwrap().to_str().unwrap(), "index_template.json")
+        }
     }
 }
 

--- a/src/service.rs
+++ b/src/service.rs
@@ -2,9 +2,9 @@
 // Parts of the code here is based on mullvad/windows-service-rs crate examples
 // Crate link: https://github.com/mullvad/windows-service-rs
 
-use futures::executor::block_on;
 use notify::event::{Event, EventKind, EventAttributes};
 use std::thread;
+use tokio::runtime::Runtime;
 
 use crate::monitor;
 use crate::rotator;
@@ -108,7 +108,9 @@ pub fn run_service() -> Result<()> {
         Ok(_v) => info!("FIM rotator thread started."),
         Err(e) => error!("Could not start FIM rotator thread, error: {}", e)
     };
-    block_on(monitor::monitor(tx, rx, cfg, ruleset));
+
+    let rt = Runtime::new().unwrap();
+    rt.block_on(monitor::monitor(tx, rx, cfg, ruleset));
 
     // Tell the system that service has stopped.
     status_handle.set_service_status(ServiceStatus {


### PR DESCRIPTION
Hello!

This PR closes #169 
We have fixed a problem related with the `index_template.json` file that can't be installed with MSI package.
Tasks:
- Included `index_template.json` in `fim.wxs` and MSI builder.
- Fixed Tokio library runtime error on Windows service.
- Bump to 0.5.1