### PR TITLE
Automate Multi‑Architecture Release Pipeline Using GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,158 @@
+name: Build & Release on Tag
+on:
+  push:
+    tags:
+      - "*"
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+# ---------------------------------------------------------
+# macOS x86_64 (self-hosted: group release, labels macOS/catalina)
+# ---------------------------------------------------------
+  build_macos_x86_64:
+    name: Build macOS x86_64
+    runs-on:
+      group: release
+      labels: [self-hosted, macOS, catalina]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build macOS package
+        run: sudo ./builder.sh
+        working-directory: ./pkg/macos
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release/fim-${{ github.ref_name }}-x86_64.pkg
+          path: pkg/macos/
+          retention-days: 1
+
+# ---------------------------------------------------------
+# DEB ARM64 (self-hosted: group release, label ARM64)
+# ---------------------------------------------------------
+  build_deb_arm64:
+    name: Build DEB ARM64
+    runs-on:
+      group: release
+      labels: [self-hosted, ARM64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup DEB ARM64 environment
+        run: mkdir -p /tmp/${{ github.ref_name }}
+
+      - name: Build DEB ARM64 package
+        run: sudo docker run -v /tmp/${{ github.ref_name }}:/tmp/output --rm docker.io/okynos/fim-builder:xenial ${{ github.ref_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release/fim-${{ github.ref_name }}-1_arm64.deb
+          path: /tmp/${{ github.ref_name }}/
+          retention-days: 1
+
+# ---------------------------------------------------------
+# DEB AMD64 (default group)
+# ---------------------------------------------------------
+  build_deb_amd64:
+    name: Build DEB AMD64
+    runs-on:
+      group: Default
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup DEB AMD64 environment
+        run: mkdir -p /tmp/${{ github.ref_name }}
+
+      - name: Build DEB AMD64 package
+        run: sudo docker run -v /tmp/${{ github.ref_name }}:/tmp/output --rm docker.io/okynos/fim-builder:xenial ${{ github.ref_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release/fim-${{ github.ref_name }}-1_amd64.deb
+          path: /tmp/${{ github.ref_name }}/
+          retention-days: 1
+
+# ---------------------------------------------------------
+# RPM x86_64 (default group)
+# ---------------------------------------------------------
+  build_rpm_x86_64:
+    name: Build RPM x86_64
+    runs-on:
+      group: Default
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup RPM x86_64 environment
+        run: mkdir -p /tmp/${{ github.ref_name }}
+
+      - name: Build RPM x86_64 package
+        run: sudo docker run -v /tmp/${{ github.ref_name }}:/tmp/output --rm docker.io/okynos/fim-builder:rhel8 ${{ github.ref_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release/fim-${{ github.ref_name }}-1.x86_64.rpm
+          path: /tmp/${{ github.ref_name }}/
+          retention-days: 1
+
+# ---------------------------------------------------------
+# RPM aarch64 (self-hosted ARM64)
+# ---------------------------------------------------------
+  build_rpm_aarch64:
+    name: Build RPM aarch64
+    runs-on:
+      group: release
+      labels: [self-hosted, ARM64]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup RPM aarch64 environment
+        run: mkdir -p /tmp/${{ github.ref_name }}
+
+      - name: Build RPM aarch64 package
+        run: sudo docker run -v /tmp/${{ github.ref_name }}:/tmp/output --rm docker.io/okynos/fim-builder:rhel8 ${{ github.ref_name }}
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: release/fim-${{ github.ref_name }}-1.aarch64.rpm
+          path: /tmp/${{ github.ref_name }}/
+          retention-days: 1
+
+  release:
+    name: Create draft release
+    needs:
+      - build_macos_x86_64
+      - build_linux_arm64
+      - build_linux_amd64
+      - build_rpm_x86_64
+      - build_rpm_aarch64
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: Create draft release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          tag_name: ${{ github.ref_name }}
+          name: "${{ github.ref_name }}"
+          files: artifacts/release/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     tags:
       - "*"
+  workflow_dispatch:
 
 permissions:
   contents: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,8 +135,8 @@ jobs:
     name: Create draft release
     needs:
       - build_macos_x86_64
-      - build_linux_arm64
-      - build_linux_amd64
+      - build_deb_arm64
+      - build_deb_amd64
       - build_rpm_x86_64
       - build_rpm_aarch64
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fim"
-version = "0.6.3"
+version = "0.6.4"
 authors = ["José Fernández <´pylott@gmail.com´>"]
 edition = "2021"
 

--- a/pkg/deb/debian/changelog
+++ b/pkg/deb/debian/changelog
@@ -1,3 +1,9 @@
+fim (0.6.4-1) xenial; urgency=medium
+
+  * More info: https://github.com/Achiefs/fim/releases/tag/v0.6.4
+
+ -- Jose Fernandez <support@achiefs.com>  Sun, 12 Apr 2026 20:47:00 +0000
+
 fim (0.6.3-1) xenial; urgency=medium
 
   * More info: https://github.com/Achiefs/fim/releases/tag/v0.6.3

--- a/pkg/rpm/fim.spec
+++ b/pkg/rpm/fim.spec
@@ -101,6 +101,9 @@ rm -fr %{buildroot}
 # -----------------------------------------------------------------------------
 
 %changelog
+* Sun Apr 12 2026 support <support@achiefs.com> - 0.6.4
+- More info: https://github.com/Achiefs/fim/releases/tag/v0.6.4
+
 * Tue Mar 03 2026 support <support@achiefs.com> - 0.6.3
 - More info: https://github.com/Achiefs/fim/releases/tag/v0.6.3
 

--- a/src/appconfig.rs
+++ b/src/appconfig.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2021, Achiefs.
 
 // Global constants definitions
-pub const VERSION: &str = "0.6.3";
+pub const VERSION: &str = "0.6.4";
 pub const NETWORK_MODE: &str = "NETWORK";
 pub const FILE_MODE: &str = "FILE";
 pub const BOTH_MODE: &str = "BOTH";


### PR DESCRIPTION
In this PR we cover the build and draft release generation of the following packages:
- macOS x86_64
- Deb amd64
- Deb arm64
- Rpm x86_64
- Rpm aarch64

Windows MSI package will be added in a later iteration.
Related issue #227 